### PR TITLE
Auto indent

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 	"icon": "images/ruby.png",
 	"categories": [
 		"Debuggers",
-		"Languages"
+		"Languages",
+		"Linters"
 	],
 	"private": false,
 	"repository": {

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ In this extension, we implement [ruby debug ide protocol](http://debug-commons.r
   * `gem install ruby-debug-ide`, the latest version is `0.6.0`. Make sure `ruby-debug-base` is installed together with ruby-debug-ide`.
 - If you are using Ruby v1.9.x (`ruby_19`, `mingw_19`)
   * `gem install ruby-debug-ide`, the latest version is `0.6.0`. Make sure `ruby-debug-base19x` is installed together with `ruby-debug-ide`.
-- If you are using Ruby v2.0.x
+- If you are using Ruby v2.x
   * `gem install ruby-debug-ide -v 0.4.32` or higher versions
   * `gem install debase -v 0.2.1` or higher versions
 

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 [![Join the chat at https://gitter.im/rebornix/vscode-ruby](https://badges.gitter.im/rebornix/vscode-ruby.svg)](https://gitter.im/rebornix/vscode-ruby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/rebornix/vscode-ruby.svg?branch=master)](https://travis-ci.org/rebornix/vscode-ruby) [![Build status](https://ci.appveyor.com/api/projects/status/s4sv1fwpjeqmgnhd?svg=true)](https://ci.appveyor.com/project/rebornix/vscode-ruby)
 
+#**This extension is now actively developed under [rubyide](https://github.com/rubyide/vscode-ruby)**
 
 This extension provides rich Ruby language and debugging support for Visual Studio Code. Fully tested against *nix/Windows and Ruby 1.9.3 to 2.2.0.
 It's still in progress ( [GitHub](https://github.com/rebornix/vscode-ruby.git) ), please expect frequent updates with breaking changes before 1.0. If you are interested in this project, feel free to

--- a/ruby.js
+++ b/ruby.js
@@ -30,7 +30,24 @@ function deferReport(uri, lint, diagnostic) {
 	diagnostic.set(uri, allOf);
 }
 
+const langConfig = {
+	comments: {
+		lineComment: "#",
+		blockComment: ["=begin", "=end"]
+	},
+	brackets: [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	],
+	indentationRules: {
+		increaseIndentPattern: /^\s*(begin|class|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)\b[^\{;]*$/
+	}
+};
+
 function activate(context) {
+	//add language config
+	vscode.languages.setLanguageConfiguration('ruby', langConfig);
 
 	let activeLinters = {};
 	let linterTimers = {};
@@ -55,7 +72,7 @@ function activate(context) {
 			}
 			linterTimers[doc.fileName] = setTimeout(() => {
 				activeLinters[doc.fileName] = linters.runCollection(lintConfig, doc.fileName, doc.getText(), result => {
-					if (!activeDiagnostics[result.linter]){
+					if (!activeDiagnostics[result.linter]) {
 						activeDiagnostics[result.linter] = vscode.languages.createDiagnosticCollection(result.linter);
 						context.subscriptions.push(activeDiagnostics[result.linter]);
 					}


### PR DESCRIPTION
Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)

Adds auto indent for opening elements requiring an `end` element, but only when they are the first word on the line.

de-indenting is not included because VSCode implements it only after the line, but an `end` tag should be at the same indentation as the opening tag. The `end` tag will need to be manually un-tabbed.