### PR TITLE
add decreaseIndentPattern

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceRoot}"
 			],
-			"sourceMaps": true,
+			"sourceMaps": false,
 			"outDir": "${workspaceRoot}/out"
 		},
 		{

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceRoot}"
 			],
-			"sourceMaps": false,
+			"sourceMaps": true,
 			"outDir": "${workspaceRoot}/out"
 		},
 		{

--- a/ruby.js
+++ b/ruby.js
@@ -41,7 +41,8 @@ const langConfig = {
 		["(", ")"]
 	],
 	indentationRules: {
-		increaseIndentPattern: /^\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\sdo\b))\b[^\{;]*$/
+		increaseIndentPattern: /^\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\sdo\b))\b[^\{;]*$/,
+		decreaseIndentPattern: /^\\s*([}\\]](,?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif|when)\\b)/
 	},
 	wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/
 };


### PR DESCRIPTION
Make sure these boxes are checked before submitting your PR -- thanks in advance!
- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)

Add `decreaseIndentPattern` to have keywords like `end` get correct auto unindent.

This is the code change in our side while seems VS Code doesn't take `decreaseIndentPattern` correctly as Atom or Sublime does, we'll wait to see when VS Code gets a fix for it.
