### PR TITLE
Auto Closing Pairs causes settings load to fail

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,0 +1,27 @@
+{
+	"comments": {
+		"lineComment": "#",
+		"blockComment": ["=begin", "=end"]
+	},
+	"brackets": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	],
+	"autoClosingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["`", "`"],
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
+		{ "open": "\"", "close": "\"", "notIn": ["string"] }
+	],
+	"surroundingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["\"", "\""],
+		["'", "'"],
+		["`", "`"]
+	]
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "Ruby",
 	"displayName": "Ruby",
-	"version": "0.5.5",
+	"version": "0.5.6",
 	"publisher": "rebornix",
 	"description": "Provides Ruby language and debugging support for Visual Studio Code",
 	"author": {

--- a/package.json
+++ b/package.json
@@ -188,7 +188,8 @@
 			"id": "ruby",
 			"aliases": ["Ruby", "ruby"],
 			"extensions": [".rb", ".rbx", ".rjs", ".Rakefile", ".rake", ".cgi", ".fcgi", ".gemspec", ".irbrc", ".capfile",
-				".ru", ".prawn", ".Gemfile", ".Guardfile", ".Vagrantfile"]
+				".ru", ".prawn", ".Gemfile", ".Guardfile", ".Vagrantfile"],
+			"configuration": "./language-configuration.json"
 		}],
 		"grammars": [{
 			"language": "ruby",

--- a/ruby.js
+++ b/ruby.js
@@ -42,14 +42,14 @@ const langConfig = {
 		["[", "]"],
 		["(", ")"]
 	],
-	autoClosingPairs: [
-		["{", "}"],
-		["[", "]"],
-		["(", ")"],
-		["\"", "\""],
-		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
-		["`", "`"]
-	],
+	// autoClosingPairs: [
+	// 	["{", "}"],
+	// 	["[", "]"],
+	// 	["(", ")"],
+	// 	["\"", "\""],
+	// 	//{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
+	// 	["`", "`"]
+	// ],
 	surroundingPairs: [
 		["{", "}"],
 		["[", "]"],

--- a/ruby.js
+++ b/ruby.js
@@ -33,31 +33,6 @@ function deferReport(uri, lint, diagnostic) {
 }
 
 const langConfig = {
-	comments: {
-		lineComment: "#",
-		blockComment: ["=begin", "=end"]
-	},
-	brackets: [
-		["{", "}"],
-		["[", "]"],
-		["(", ")"]
-	],
-	// autoClosingPairs: [
-	// 	["{", "}"],
-	// 	["[", "]"],
-	// 	["(", ")"],
-	// 	["\"", "\""],
-	// 	//{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
-	// 	["`", "`"]
-	// ],
-	surroundingPairs: [
-		["{", "}"],
-		["[", "]"],
-		["(", ")"],
-		["\"", "\""],
-		["'", "'"],
-		["`", "`"]
-	],
 	indentationRules: {
 		increaseIndentPattern: /^\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\sdo\b))\b[^\{;]*$/
 	},


### PR DESCRIPTION
Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)

Auto Closing Pairs only works if the language settings are in a file - more specifically, it doesn't work when loading settings with `setLanguageConfiguration` which is flat out crazy. This is currently causing indenting to fail.

This is totally my fault because I suggested that those setting be placed in the langConfig passed to `setLanguageConfiguration`.

Version bumped in `package.json` ready for deployment.