### PR TITLE
Recognize .jbuilder file extension as Ruby

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
 			"id": "ruby",
 			"aliases": ["Ruby", "ruby"],
 			"extensions": [".rb", ".rbx", ".rjs", ".Rakefile", ".rake", ".cgi", ".fcgi", ".gemspec", ".irbrc", ".capfile",
-				".ru", ".prawn", ".Gemfile", ".Guardfile", ".Vagrantfile"
+				".ru", ".prawn", ".jbuilder", ".Gemfile", ".Guardfile", ".Vagrantfile"
 			],
 			"configuration": "./language-configuration-ruby.json"
 		}, {

--- a/syntaxes/ruby.tmLanguage
+++ b/syntaxes/ruby.tmLanguage
@@ -59,6 +59,7 @@
     <string>capfile</string>
     <string>ru</string>
     <string>prawn</string>
+    <string>jbuilder</string>
     <string>Gemfile</string>
     <string>Guardfile</string>
     <string>Vagrantfile</string>


### PR DESCRIPTION
Adds support for recognizing [.jbuilder](https://github.com/rails/jbuilder) files as Ruby automatically.

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)
