### PR TITLE
Use rootDir for cwd to obey relative exclude path in rubocop

### DIFF
--- a/lint/lib/linters/RuboCop.js
+++ b/lint/lib/linters/RuboCop.js
@@ -6,7 +6,7 @@ function RuboCop(opts) {
 	this.path = opts.path;
 	this.responsePath = "stdout";
 
-	this.args = ["-s", "-f", "json", "abc.rb"];
+	this.args = ["-s", "-f", "json", "--force-exclusion", "{path}"];
 
 	if (opts.lint) this.args.push("-l");
 	if (opts.only) this.args = this.args.concat("--only", opts.only.join(','));

--- a/lint/lintCollection.js
+++ b/lint/lintCollection.js
@@ -4,16 +4,17 @@ const Linter = require('./lib/linter');
 const LintResults = require('./lib/lintResults');
 
 class LintCollection {
-	constructor(config) {
+	constructor(config, rootPath) {
 		this._results = {};
 		this._docLinters = {};
 		this._cfg = {};
 		this.cfg(config);
+		this._rootPath = rootPath;
 	}
 	run(doc) {
 		if (!doc) return;
 		if (doc.languageId !== 'ruby') return;
-		if (!this._docLinters[doc.fileName]) this._docLinters[doc.fileName] = new Linter(doc, this._update.bind(this, doc));
+		if (!this._docLinters[doc.fileName]) this._docLinters[doc.fileName] = new Linter(doc, this._rootPath, this._update.bind(this, doc));
 		this._docLinters[doc.fileName].run(this._cfg);
 	}
 	_update(doc, result) {

--- a/ruby.js
+++ b/ruby.js
@@ -138,7 +138,7 @@ function activate(context) {
 	//add language config
 	vscode.languages.setLanguageConfiguration('ruby', langConfig);
 
-	const linters = new LintCollection(vscode.workspace.getConfiguration("ruby").lint);
+	const linters = new LintCollection(vscode.workspace.getConfiguration("ruby").lint, vscode.workspace.rootPath);
 	subs.push(linters);
 
 	function changeTrigger(changed) {


### PR DESCRIPTION
Expected:

In rails project, `spec/foo/foobar_spec.rb` should not be claimed by cop `Metrics/BlockLength`, because it is [excluded by default config](https://github.com/bbatsov/rubocop/blob/aeaab434ac32e33cc9e22839f2079e905590fce6/config/default.yml#L1162)

Actual without this PR:

Warning is shown for BlockLength.

----

By rubocop's design, exclude paths in default config is relative to working dir, not to the dir contains `.rubocop.yml`.
https://github.com/bbatsov/rubocop/issues/3145

So this PR use workspace.rootPath for cwd.

----

Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [ ] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)