### PR TITLE
Use new configurationDefaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
 			"language": "erb",
 			"path": "./snippets/erb.json"
 		}],
+		"configurationDefaults": {
+			"[ruby]": {
+				"editor.tabSize": 2
+			}
+		},
 		"configuration": {
 			"title": "ruby language settings",
 			"properties": {


### PR DESCRIPTION
I noticed the indentation was not being set properly in the editor when opening up ruby files. This pull is rather small and could provide a starting point for other editor settings that would benefit from ruby specific defaults.

This adds a configurationDefaults entry to package.json to allow per
language editor settings by default.

Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [] Build pass!
- [] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)