### PR TITLE
Add config to set Unicode handling on `ruby -wc` linting

### DIFF
--- a/lint/lib/linters/Ruby.js
+++ b/lint/lib/linters/Ruby.js
@@ -8,6 +8,10 @@ function RubyWC(opts) {
 	this.ext = "";
 	this.path = opts.path;
 	this.args = ["-wc"];
+
+	if(opts.unicode) {
+		this.args.push("-Ku");
+	}
 }
 
 RubyWC.prototype.processResult = function(data) {

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,9 @@ Enable each one in your workspace or user settings:
 
 //advanced: set command line options for some linters:
 "ruby.lint": {
+	"ruby": {
+		"unicode": true //Runs ruby -wc -Ku
+	},
 	"rubocop": {
 		"only": ["SpaceInsideBlockBraces", "LeadingCommentSpace"],
 		"lint": true,


### PR DESCRIPTION
I use non-Ascii characters frequently, and since Ruby 2.0 source files are handled as UTF8 by default. `ruby -wc` however does not handle that correctly unless you pass a extra argument for forcing the character set (`-Ku`).

Because I don't know if people rely on the old behavior, this PR adds a flag for the RubyWC linter for enabling Unicode handling, disabled by default.

- [] Build pass!
- [] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)