### PR TITLE
Stacktrace fails when file does not exists

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -272,7 +272,7 @@ class RubyDebugSession extends DebugSession {
 
             response.body = {
                 stackFrames: results.map(stack => new StackFrame(+stack.no,
-                    his._activeFileData.has(this.convertDebuggerPathToClient(stack.file)) && this._activeFileData.get(this.convertDebuggerPathToClient(stack.file))[+stack.line-1] ?
+                    this._activeFileData.has(this.convertDebuggerPathToClient(stack.file)) && this._activeFileData.get(this.convertDebuggerPathToClient(stack.file))[+stack.line-1] ?
 						this._activeFileData.get(this.convertDebuggerPathToClient(stack.file))[+stack.line-1].trim()
 						: "<Source not available>",
                     new Source(basename(stack.file), this.convertDebuggerPathToClient(stack.file)),


### PR DESCRIPTION
I had an issue on an old ruby 1.9.3 project where the function generating the stack trace is failing because of a stack trace line being on file <internal:prelude>, which does not exists and a trace on line 0, which result in trying to access line -1 in the array containing files content.

The following pull request is a quick fix that : 
- does not try to fetch content from files that does not exists
- set source code to "<Source not available>" when the file or the line does not exists

