### PR TITLE
Show method names in debugger call stack

### DIFF
--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,10 +1,10 @@
 import * as parse from 'ruby-method-locate';
 
 interface Symbol {
-	name: string,
-	type: 'module' | 'class' | 'method' | 'classMethod',
-	line: number,
-	containerName: string
+    name: string,
+    type: 'module' | 'class' | 'method' | 'classMethod',
+    line: number,
+    containerName: string
 }
 
 const DECLARATION_TYPES = ['class', 'module', 'method', 'classMethod'];
@@ -16,53 +16,53 @@ const flatMap = (xs,f) => xs.map(f).reduce(concat, []);
 //  1. this produces a flat array of Symbols, rather than a nested object
 //  2. this doesn't use lodash
 function flatten(locateInfo: any, containerName?: string): Symbol[] {
-	return flatMap(Object.keys(locateInfo), type => {
-		const symbols = locateInfo[type];
-		if (DECLARATION_TYPES.indexOf(type) === -1) {
-			// Skip top-level include or posn property etc.
-			return [];
-		}
-		return flatMap(Object.keys(symbols), name => {
-			const inner = symbols[name];
-			const symbolInfo = {
-				name: name,
-				type: type,
-				line: inner.posn ? inner.posn.line : 0,
-				containerName: containerName || ''
-			};
+    return flatMap(Object.keys(locateInfo), type => {
+        const symbols = locateInfo[type];
+        if (DECLARATION_TYPES.indexOf(type) === -1) {
+            // Skip top-level include or posn property etc.
+            return [];
+        }
+        return flatMap(Object.keys(symbols), name => {
+            const inner = symbols[name];
+            const symbolInfo = {
+                name: name,
+                type: type,
+                line: inner.posn ? inner.posn.line : 0,
+                containerName: containerName || ''
+            };
             const sep = { method: '#', classMethod: '.' }[type] || '::';
-	        const fullName = containerName ? `${containerName}${sep}${name}` : name;
+            const fullName = containerName ? `${containerName}${sep}${name}` : name;
 
-			return [symbolInfo].concat(flatten(inner, fullName));
-		});
-	});
+            return [symbolInfo].concat(flatten(inner, fullName));
+        });
+    });
 }
 
 export class SymbolLocator {
     private symbols: Promise<Symbol[]>;
 
     constructor(fileName: string) {
-		this.symbols = parse(fileName).then(flatten);
+        this.symbols = parse(fileName).then(flatten);
     }
 
     symbolForLine(lineNumber: number): Promise<string> {
-		return this.symbols.then(symbols => {
-			let closestSymbol;
-			for (const candidate of symbols) {
-				if (lineNumber >= candidate.line && (!closestSymbol || candidate.line > closestSymbol.line)) {
-					closestSymbol = candidate;
-				}
-			}
-			return this.formatSymbol(closestSymbol);
-		});
+        return this.symbols.then(symbols => {
+            let closestSymbol;
+            for (const candidate of symbols) {
+                if (lineNumber >= candidate.line && (!closestSymbol || candidate.line > closestSymbol.line)) {
+                    closestSymbol = candidate;
+                }
+            }
+            return this.formatSymbol(closestSymbol);
+        });
     }
 
-	formatSymbol(symbol?: Symbol): string {
-		if (!symbol) {
-			return "(Unknown symbol)";
-		}
+    formatSymbol(symbol?: Symbol): string {
+        if (!symbol) {
+            return "(Unknown symbol)";
+        }
 
-		const name = symbol.type === 'classMethod' ? `::${symbol.name}` : symbol.name;
-		return symbol.containerName ? `${name} (${symbol.containerName})` : name;
-	}
+        const name = symbol.type === 'classMethod' ? `::${symbol.name}` : symbol.name;
+        return symbol.containerName ? `${name} (${symbol.containerName})` : name;
+    }
 }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,0 +1,68 @@
+import * as parse from 'ruby-method-locate';
+
+interface Symbol {
+	name: string,
+	type: 'module' | 'class' | 'method' | 'classMethod',
+	line: number,
+	containerName: string
+}
+
+const DECLARATION_TYPES = ['class', 'module', 'method', 'classMethod'];
+
+const concat = (x,y) => x.concat(y);
+const flatMap = (xs,f) => xs.map(f).reduce(concat, []);
+
+// this is adapted from the flatten function in locate.js, the differences are:
+//  1. this produces a flat array of Symbols, rather than a nested object
+//  2. this doesn't use lodash
+function flatten(locateInfo: any, containerName?: string): Symbol[] {
+	return flatMap(Object.keys(locateInfo), type => {
+		const symbols = locateInfo[type];
+		if (DECLARATION_TYPES.indexOf(type) === -1) {
+			// Skip top-level include or posn property etc.
+			return [];
+		}
+		return flatMap(Object.keys(symbols), name => {
+			const inner = symbols[name];
+			const symbolInfo = {
+				name: name,
+				type: type,
+				line: inner.posn ? inner.posn.line : 0,
+				containerName: containerName || ''
+			};
+            const sep = { method: '#', classMethod: '.' }[type] || '::';
+	        const fullName = containerName ? `${containerName}${sep}${name}` : name;
+
+			return [symbolInfo].concat(flatten(inner, fullName));
+		});
+	});
+}
+
+export class SymbolLocator {
+    private symbols: Promise<Symbol[]>;
+
+    constructor(fileName: string) {
+		this.symbols = parse(fileName).then(flatten);
+    }
+
+    symbolForLine(lineNumber: number): Promise<string> {
+		return this.symbols.then(symbols => {
+			let closestSymbol;
+			for (const candidate of symbols) {
+				if (lineNumber >= candidate.line && (!closestSymbol || candidate.line > closestSymbol.line)) {
+					closestSymbol = candidate;
+				}
+			}
+			return this.formatSymbol(closestSymbol);
+		});
+    }
+
+	formatSymbol(symbol?: Symbol): string {
+		if (!symbol) {
+			return "(Unknown symbol)";
+		}
+
+		const name = symbol.type === 'classMethod' ? `::${symbol.name}` : symbol.name;
+		return symbol.containerName ? `${name} (${symbol.containerName})` : name;
+	}
+}

--- a/src/typings/ruby-method-locate/ruby-method-locate.d.ts
+++ b/src/typings/ruby-method-locate/ruby-method-locate.d.ts
@@ -1,0 +1,6 @@
+
+declare module 'ruby-method-locate' {
+	namespace parse {}
+	function parse(fileName: string): Promise<any>;
+	export = parse;
+}

--- a/src/typings/ruby-method-locate/ruby-method-locate.d.ts
+++ b/src/typings/ruby-method-locate/ruby-method-locate.d.ts
@@ -1,6 +1,6 @@
 
 declare module 'ruby-method-locate' {
-	namespace parse {}
-	function parse(fileName: string): Promise<any>;
-	export = parse;
+    namespace parse {}
+    function parse(fileName: string): Promise<any>;
+    export = parse;
 }


### PR DESCRIPTION
Uses the ruby-method-locate module to get a list of the symbols (modules, classes, methods, etc) in each file mentioned in the stacktrace. Looks up the closest containing symbol for each line.

<img width="534" alt="screen shot 2017-05-10 at 20 31 50" src="https://cloud.githubusercontent.com/assets/158660/25920342/8a8b3ebe-35c9-11e7-8185-a08bcaf1ad24.png">

Format is: method name (with ::prefix for class/module methods), followed by full class/module name in brackets.

Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)