### PR TITLE
Fix snippet syntax errors

### DIFF
--- a/snippets/erb.json
+++ b/snippets/erb.json
@@ -2,7 +2,7 @@
 	"if": {
 		"prefix": "if",
 		"body": [
-			"<% if ${true} %>",
+			"<% if ${1:truevalue} %>",
 			"  $2",
 			"<% end %>"
 		],
@@ -18,7 +18,7 @@
 	"elsif": {
 		"prefix": "elsif",
 		"body": [
-			"<% elsif ${true} %>"
+			"<% elsif ${1:truevalue} %>"
 		],
 		"description": "elsif"
 	},
@@ -32,10 +32,10 @@
 	"ife": {
 		"prefix": "ife",
 		"body": [
-			"<% if ${true} %>",
-			"  $1",
-			"<% else %>",
+			"<% if ${1:truevalue} %>",
 			"  $2",
+			"<% else %>",
+			"  $3",
 			"<% end %>"
 		],
 		"description": "if .. else .. end"
@@ -43,7 +43,7 @@
 	"unless": {
 		"prefix": "unless",
 		"body": [
-			"<% unless ${false} %>",
+			"<% unless ${1:falsevalue} %>",
 			"  $2",
 			"<% end %>"
 		],
@@ -52,10 +52,10 @@
 	"unlesse": {
 		"prefix": "unlesse",
 		"body": [
-			"<% unless ${false} %>",
-			"  $1",
-			"<% else %>",
+			"<% unless ${1:falsevalue} %>",
 			"  $2",
+			"<% else %>",
+			"  $3",
 			"<% end %>"
 		],
 		"description": "unless .. end"
@@ -63,8 +63,8 @@
 	"each": {
 		"prefix": "each",
 		"body": [
-			"<% ${items}.each do |${item}| %>",
-			"  $1",
+			"<% ${1:items}.each do |${2:item}| %>",
+			"  $2",
 			"<% end %>"
 		],
 		"description": "each do"

--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -50,7 +50,7 @@
 	"Class definition with initialize": {
 		"prefix": "class init",
 		"body": [
-			"class ${ClassName}",
+			"class ${1:ClassName}",
 			"\tdef initialize",
 			"\t\t$0",
 			"\tend",
@@ -60,7 +60,7 @@
 	"Class definition": {
 		"prefix": "class",
 		"body": [
-			"class ${ClassName}",
+			"class ${1:ClassName}",
 			"\t$0",
 			"end"
 		]
@@ -68,7 +68,7 @@
 	"for loop": {
 		"prefix": "for",
 		"body": [
-			"for ${value} in ${enumerable} do",
+			"for ${1:value} in ${2:enumerable} do",
 			"\t$0",
 			"end"
 		]
@@ -76,7 +76,7 @@
 	"if": {
 		"prefix": "if",
 		"body": [
-			"if ${test}",
+			"if ${1:test}",
 			"\t$0",
 			"end"
 		]
@@ -94,7 +94,7 @@
 	"if elsif": {
 		"prefix": "if elsif",
 		"body": [
-			"if ${test}",
+			"if ${1:test}",
 			"\t$0",
 			"elsif ",
 			"\t",
@@ -104,7 +104,7 @@
 	"if elsif else": {
 		"prefix": "if elsif else",
 		"body": [
-			"if ${test}",
+			"if ${1:test}",
 			"\t$0",
 			"elsif ",
 			"\t",
@@ -124,7 +124,7 @@
 	"Module definition": {
 		"prefix": "module",
 		"body": [
-			"module ${ModuleName}",
+			"module ${1:ModuleName}",
 			"\t$0",
 			"end"
 		]
@@ -132,7 +132,7 @@
 	"unless": {
 		"prefix": "unless",
 		"body": [
-			"unless ${test}",
+			"unless ${1:test}",
 			"\t$0",
 			"end"
 		]
@@ -140,7 +140,7 @@
 	"until loop": {
 		"prefix": "until",
 		"body": [
-			"until ${test}",
+			"until ${1:test}",
 			"\t$0",
 			"end"
 		]
@@ -148,7 +148,7 @@
 	"while loop": {
 		"prefix": "while",
 		"body": [
-			"while ${test}",
+			"while ${1:test}",
 			"\t$0",
 			"end"
 		]
@@ -156,7 +156,7 @@
 	"method definition": {
 		"prefix": "def",
 		"body": [
-			"def ${method_name}",
+			"def ${1:method_name}",
 			"\t$0",
 			"end"
 		]


### PR DESCRIPTION
Trying to remove these errors in VS Code 1.13+ due to wrongly typed snippet variables.

```
...vscode/extensions/rebornix.ruby-0.12.1]: The "each"-snippet very likely confuses snippet-variables and snippet-placeholders. See https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details.
```

Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)