### PR TITLE
Add filenames to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,23 +212,14 @@
 		"languages": [{
 			"id": "ruby",
 			"aliases": ["Ruby", "ruby"],
-			"extensions": [".rb", ".rbx", ".rjs", ".Rakefile", ".rake", ".cgi", ".fcgi", ".gemspec", ".irbrc", ".capfile",
-				".ru", ".prawn", ".jbuilder"
+			"extensions": [
+				".cgi", ".fcgi", ".gemspec", ".irbrc", ".jbuilder",
+				".prawn", ".rake", ".rb", ".rbx", ".rjs", ".ru"
 			],
 			"filenames": [
-				"appfile",
-				"appraisals",
-				"berksfile",
-				"brewfile",
-				"capfile",
-				"fastfile",
-				"gemfile",
-				"guardfile",
-				"podfile",
-				"puppetfile",
-				"rakefile",
-				"thorfile",
-				"vagrantfile"
+				"appfile", "appraisals", "berksfile", "brewfile", "capfile",
+				"fastfile", "gemfile", "guardfile", "podfile", "puppetfile",
+				"rakefile", "thorfile", "vagrantfile"
 			],
 			"configuration": "./language-configuration-ruby.json"
 		}, {

--- a/package.json
+++ b/package.json
@@ -213,7 +213,22 @@
 			"id": "ruby",
 			"aliases": ["Ruby", "ruby"],
 			"extensions": [".rb", ".rbx", ".rjs", ".Rakefile", ".rake", ".cgi", ".fcgi", ".gemspec", ".irbrc", ".capfile",
-				".ru", ".prawn", ".jbuilder", ".Gemfile", ".Guardfile", ".Vagrantfile"
+				".ru", ".prawn", ".jbuilder"
+			],
+			"filenames": [
+				"appfile",
+				"appraisals",
+				"berksfile",
+				"brewfile",
+				"capfile",
+				"fastfile",
+				"gemfile",
+				"guardfile",
+				"podfile",
+				"puppetfile",
+				"rakefile",
+				"thorfile",
+				"vagrantfile"
 			],
 			"configuration": "./language-configuration-ruby.json"
 		}, {

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
 			],
 			"filenames": [
 				"appfile", "appraisals", "berksfile", "brewfile", "capfile", "fastfile", "gemfile", "guardfile", "podfile",
-				"puppetfile", "rakefile", "snapfile", "thorfile", "vagrantfile"
+				"puppetfile", "rakefile", "snapfile", "thorfile", "vagrantfile", "dangerfile"
 			],
 			"configuration": "./language-configuration-ruby.json"
 		}, {

--- a/package.json
+++ b/package.json
@@ -213,13 +213,13 @@
 			"id": "ruby",
 			"aliases": ["Ruby", "ruby"],
 			"extensions": [
-				".cgi", ".fcgi", ".gemspec", ".irbrc", ".jbuilder",
-				".prawn", ".rake", ".rb", ".rbx", ".rjs", ".ru"
+				".builder", ".cgi", ".fcgi", ".gemspec", ".god", ".irbrc", ".jbuilder", ".mspec", ".pluginspec", ".podspec",
+				".prawn", ".pryrc", ".rabl", ".rake", ".rb", ".rbuild", ".rbw", ".rbx", ".rjs", ".ru", ".ruby", ".spec",
+				".thor", ".watchr"
 			],
 			"filenames": [
-				"appfile", "appraisals", "berksfile", "brewfile", "capfile",
-				"fastfile", "gemfile", "guardfile", "podfile", "puppetfile",
-				"rakefile", "thorfile", "vagrantfile"
+				"appfile", "appraisals", "berksfile", "brewfile", "capfile", "fastfile", "gemfile", "guardfile", "podfile",
+				"puppetfile", "rakefile", "snapfile", "thorfile", "vagrantfile"
 			],
 			"configuration": "./language-configuration-ruby.json"
 		}, {


### PR DESCRIPTION
This pull request is to add `"filenames"` entry to `"languages"` section. By using this configuration, some file without extension such as `Gemfile` or `Puppetfile` is recognized as ruby.  
Also fix  #162 


Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)