### PR TITLE
Fix type of ruby linter property

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
 					"description": "Set individual ruby linters to use",
 					"properties": {
 						"ruby": {
-							"type": "boolean",
+							"type": ["boolean", "object"],
 							"default": false,
 							"description": "Use ruby -wc to lint"
 						},


### PR DESCRIPTION
In `ruby.lint` settings, the `ruby` linter can have not only `boolean` but also `object` value, for example, the readme says:

```js
"ruby.lint": {
	"ruby": {
		"unicode": true //Runs ruby -wc -Ku
	},
```

However, since current property of `ruby` linter only accepts `boolean`, setting an object as `ruby` linter configuration complains that there exists a type mismatch.

So I have changed the property setting of `ruby` linter to accept either `boolean` or `object`.

- [] Build pass!
- [] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)