### PR TITLE
Fix bug in indentation of "private def" methods

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -15,7 +15,7 @@ export function activate(context: ExtensionContext) {
 	// register language config
 	vscode.languages.setLanguageConfiguration('ruby', {
 		indentationRules: {
-			increaseIndentPattern: /^\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\sdo\b))\b[^\{;]*$/,
+			increaseIndentPattern: /^\s*((begin|class|private def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\sdo\b))\b[^\{;]*$/,
 			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
 		},
 		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/


### PR DESCRIPTION
There was a bug in the plugin's auto-indentation where a method declared
as private on the same line as its definition would fail to indent
correctly.

"private def" was added as a keyword in the regex to keep the regex
simple and explicit. Reading the code shows you that "private def" is
something for which the editor should increase the indentation level
automatically.

Fixes rubyide/vscode-ruby#203

Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [] Build pass!
- [] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)