### PR TITLE
adjust erb comment configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
  - nvm install v6.9.1
  - nvm use v6.9.1
 before_script:
-  - npm install -g typescript -v 2.1.5
   - npm install
-  - tsc -p ./src
+  -  npm run compile
 script: npm run test-debugger

--- a/language-configuration-erb.json
+++ b/language-configuration-erb.json
@@ -1,6 +1,7 @@
 {
 	"comments": {
-		"blockComment": [ "<%#", "%>" ]
+		"lineComment": "#",
+		"blockComment": ["=begin", "=end"]
 	},
 	"brackets": [
 		["{", "}"],


### PR DESCRIPTION
Some times I need to program more ruby code in `erb`, i.e:

```
<%
  set_meta_tags title: "title",
                og: {
                    title: "my title",
                    description: "some description"
                },
                image: "image path"
%>
```
vscode-ruby [default comment](https://github.com/rubyide/vscode-ruby/blob/master/language-configuration-erb.json#L3) will create `<%# %>`, may look like

```
<%
  set_meta_tags title: "title",
                og: {
                    title: "my title",
                    description: "some description"
                },
                <%# image: "image path" %>
%>
```

but the ideal comment should be 

```
<%
  set_meta_tags title: "title",
                og: {
                    title: "my title",
                    description: "some description"
                },
                # image: "image path"
%
```
so I adjust the comment configuration