### PR TITLE
Update indent pattern

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -15,7 +15,7 @@ export function activate(context: ExtensionContext) {
 	// register language config
 	vscode.languages.setLanguageConfiguration('ruby', {
 		indentationRules: {
-			increaseIndentPattern: /^\s*((begin|class|((private|protected)\s+)?def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^\{;]|("|'|\/).+\4)*$/,
+			increaseIndentPattern: /^\s*((begin|class|((private|protected)\s+)?def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^\{;]|("|'|\/).*\4)*$/,
 			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
 		},
 		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -13,13 +13,13 @@ import { registerTaskProvider } from './task/rake';
 export function activate(context: ExtensionContext) {
 	const subs = context.subscriptions;
 	// register language config
-	vscode.languages.setLanguageConfiguration("ruby", {
-    indentationRules: {
-      increaseIndentPattern: /^\s*((begin|class|((private|protected)\s+)?def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^\{;]|("|'|\/).+\4)*$/,
-      decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
-    },
-    wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/
-  })
+	vscode.languages.setLanguageConfiguration('ruby', {
+		indentationRules: {
+			increaseIndentPattern: /^\s*((begin|class|((private|protected)\s+)?def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^\{;]|("|'|\/).+\4)*$/,
+			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
+		},
+		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/
+	});
 
 	registerHighlightProvider(context);
 	registerLinters(context);

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -15,7 +15,7 @@ export function activate(context: ExtensionContext) {
 	// register language config
 	vscode.languages.setLanguageConfiguration('ruby', {
 		indentationRules: {
-			increaseIndentPattern: /^\s*((begin|class|((private|protected)\s+)?def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^\{;]|("|'|\/).*\4)*$/,
+			increaseIndentPattern: /^\s*((begin|class|((private|protected)\s+)?def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^#\{;]|("|'|\/).*\4)*(#.*)$/,
 			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
 		},
 		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -13,13 +13,13 @@ import { registerTaskProvider } from './task/rake';
 export function activate(context: ExtensionContext) {
 	const subs = context.subscriptions;
 	// register language config
-	vscode.languages.setLanguageConfiguration('ruby', {
-		indentationRules: {
-			increaseIndentPattern: /^\s*((begin|class|(private|protected)\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|(.*\sdo\b)|(.*=\s*(case|if|unless)))\b[^;]*$/,
-			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
-		},
-		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/
-	});
+	vscode.languages.setLanguageConfiguration("ruby", {
+    indentationRules: {
+      increaseIndentPattern: /^\s*((begin|class|((private|protected)\s+)?def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^\{;]|("|'|\/).+\4)*$/,
+      decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
+    },
+    wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/
+  })
 
 	registerHighlightProvider(context);
 	registerLinters(context);

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -15,7 +15,7 @@ export function activate(context: ExtensionContext) {
 	// register language config
 	vscode.languages.setLanguageConfiguration('ruby', {
 		indentationRules: {
-			increaseIndentPattern: /^\s*((begin|class|((private|protected)\s+)?def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^#\{;]|("|'|\/).*\4)*(#.*)$/,
+			increaseIndentPattern: /^\s*((begin|class|((private|protected)\s+)?def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^#\{;]|("|'|\/).*\4)*(#.*)?$/,
 			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
 		},
 		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -15,7 +15,7 @@ export function activate(context: ExtensionContext) {
 	// register language config
 	vscode.languages.setLanguageConfiguration('ruby', {
 		indentationRules: {
-			increaseIndentPattern: /^\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|(.*\sdo\b)|(.*=\s*(case|if|unless)))\b[^\{;]*$/,
+			increaseIndentPattern: /^\s*((begin|class|(private|protected)\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|(.*\sdo\b)|(.*=\s*(case|if|unless)))\b[^;]*$/,
 			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
 		},
 		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -15,7 +15,7 @@ export function activate(context: ExtensionContext) {
 	// register language config
 	vscode.languages.setLanguageConfiguration('ruby', {
 		indentationRules: {
-			increaseIndentPattern: /^\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\sdo\b))\b[^\{;]*$/,
+			increaseIndentPattern: /^\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|(.*\sdo\b)|(.*=\s*(case|if|unless)))\b[^\{;]*$/,
 			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
 		},
 		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/


### PR DESCRIPTION
- [ ] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)

Refer the following pull request and the issues linked in it:
https://github.com/Microsoft/vscode/pull/40049

@rebornix 
This PR seems to come into a bit of conflict with #223, should make a decision on which one we're going to use.
 
Here's the thing:
1. If `case` doesn't indent the next line and `when` doesn't unindent, the indentation will be ok only while we're adding `when` clauses, but will break when we use `else` and/or `end` (because these 2  do unindent). The result of using the changes made in #233 would be this:
```rb
  case thing
  when 2 then true
  when 4 then false
else nil
end
```

2. With this PR the `case` statement does indent the next line but any of `when`, `else` and `end` will unindent leading to a desired output:

```rb
  case thing
  when 2 then true
  when 4 then false
  else nil
  end
```