### PR TITLE
define the 'includes' field in the debug configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,6 +402,11 @@
                 "type": "string",
                 "description": "If you want to run more than one debugger, you can specify the port here.",
                 "default": "1234"
+              },
+              "includes": {
+                "type": "array",
+                "description": "Additional paths to be added to Ruby's include path",
+                "default": []
               }
             }
           },

--- a/src/debugger/ruby.ts
+++ b/src/debugger/ruby.ts
@@ -207,6 +207,13 @@ export class RubyProcess extends EventEmitter {
                     runtimeExecutable = args.pathToBundler;
                 }
             }
+
+            if (args.includes){
+                args.includes.forEach((path) => {
+                    runtimeArgs.push('-I')
+                    runtimeArgs.push(path)
+                })
+            }
             // '--' forces process arguments (args.args) not to be swollowed by rdebug-ide
             this.debugprocess = childProcess.spawn(runtimeExecutable, [...runtimeArgs, '--', args.program, ...args.args || []], {cwd: processCwd, env: processEnv});
 


### PR DESCRIPTION
This adds an includes fields in the ruby tasks, which are passed as `-I` to rdebug-ide.

Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)
  