### PR TITLE
Add firstLine regex to Ruby language definition (resolves #245)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.0.0
   - 1.9.3
+  - 2.0.0
+  - 2.1.10
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
 
 before_install:
- - gem install ruby-debug-ide
- - nvm install v6.9.1
- - nvm use v6.9.1
+  - gem install ruby-debug-ide
+  - nvm install 8.9.3
+  - echo "8.9.3" > .nvmrc
+
 before_script:
+  - nvm use
   - npm install -g typescript -v 2.1.5
   - npm install
-  - tsc -p ./src
-script: npm run test-debugger
+  - npm run compile
+script: nvm use && npm run test-debugger

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,3 +27,5 @@ environment:
     - ruby_version: "22-x64"
     - ruby_version: "23"
     - ruby_version: "23-x64"
+    - ruby_version: "24"
+    - ruby_version: "24-x64"

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
           "Ruby",
           "ruby"
         ],
-        "firstLine": "^#!\\s*/.*\\bruby\\b",
+        "firstLine": "^#!\\s*/.*(?:ruby|rbx|rake)\\b",
         "extensions": [
           ".builder",
           ".cgi",

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
           "Ruby",
           "ruby"
         ],
+        "firstLine": "^#!\\s*/.*\\bruby\\b",
         "extensions": [
           ".builder",
           ".cgi",

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,11 @@
 # Ruby Language and Debugging Support for Visual Studio Code
 
-[![Join the chat at https://rubyide-slackin.azurewebsites.net](./images/badge.png)](https://rubyide-slackin.azurewebsites.net) [![Build Status](https://api.travis-ci.org/rubyide/vscode-ruby.svg?branch=master)](https://travis-ci.org/rubyide/vscode-ruby) [![Build status](https://ci.appveyor.com/api/projects/status/vlgs2y7tsc4xpj4c?svg=true)](https://ci.appveyor.com/project/rebornix/vscode-ruby)
+[![Join the chat at https://rubyide-slackin.azurewebsites.net](./images/badge.png)](https://rubyide-slackin.azurewebsites.net)
+[![Build Status](https://travis-ci.org/wingrunr21/vscode-ruby-lang.svg?branch=master)](https://travis-ci.org/wingrunr21/vscode-ruby-lang)
+[![Build status](https://ci.appveyor.com/api/projects/status/satow2kjho27kph6?svg=true)](https://ci.appveyor.com/project/wingrunr21/vscode-ruby-lang)
 
-This extension provides rich Ruby language and debugging support for VS Code. It's still in progress ( [GitHub](https://github.com/rubyide/vscode-ruby.git) ), please expect frequent updates with breaking changes before 1.0. 
+
+This extension provides rich Ruby language and debugging support for VS Code. It's still in progress ( [GitHub](https://github.com/rubyide/vscode-ruby.git) ), please expect frequent updates with breaking changes before 1.0.
 
 It started as a personal project of [@rebornix](https://github.com/rebornix), aiming to bring Ruby debugging experience to VS Code. Then it turned to be a community driven project. With his amazing commits, [@HookyQR](https://github.com/HookyQR) joined as a contributor and brought users Linting/Formatting/etc, made the debugger more robust and more! If you are interested in this project, feel free to join the [community](https://github.com/rubyide/vscode-ruby/graphs/contributors):  file [issues](https://github.com/rubyide/vscode-ruby/issues/new), fork [our project](https://github.com/rubyide/vscode-ruby) and hack it around and send us PRs, or subscribe to our [mailing list](http://eepurl.com/bTBAfv).
 


### PR DESCRIPTION
Adds a `firstLine` definition so files with a ruby shebang are detected correctly

- [] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)