### PR TITLE
Fix shebang detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
           "Ruby",
           "ruby"
         ],
-        "firstLine": "^#!\\s*/.*\\bruby\\b",
+        "firstLine": "^#!\\s*/.*(?:ruby|rbx|rake)\\b",
         "extensions": [
           ".builder",
           ".cgi",

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
           "Ruby",
           "ruby"
         ],
+        "firstLine": "^#!\\s*/.*\\bruby\\b",
         "extensions": [
           ".builder",
           ".cgi",


### PR DESCRIPTION
Adds a `firstLine` definition so files with a ruby shebang are detected correctly

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)