### PR TITLE
Fix getEntry regex to handle additional cases

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -52,8 +52,7 @@ function registerHighlightProvider(ctx: ExtensionContext) {
 	}
 
 	const getEntry = function(line) {
-		//only lines that start with the entry
-		let match = line.text.match(/^(\s*)(begin|class|def|for|if|module|unless|until|case|while)\b[^\{;]*$/);
+		let match = line.text.match(/^(.*\b)(begin|class|def|for|if|module|unless|until|case|while)\b[^;]*$/);
 		if (match) {
 			return new vscode.Range(line.lineNumber, match[1].length, line.lineNumber, match[1].length + match[2].length);
 		} else {


### PR DESCRIPTION
This updates the entry regex to handle the uses cases outlined in #234. The original regex did not correctly match on patterns like `def foo(params = {})` or `bar = if ...`.

This fixes #234.

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)