### PR TITLE
Indent patterns (again)

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -15,8 +15,8 @@ export function activate(context: ExtensionContext) {
 	// register language config
 	vscode.languages.setLanguageConfiguration('ruby', {
 		indentationRules: {
-			increaseIndentPattern: /^\s*((begin|class|((private|protected)\s+)?def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^#\{;]|("|'|\/).*\4)*(#.*)?$/,
-			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif)\b)/
+			increaseIndentPattern: /^(\s*(module|class|((private|protected)\s+)?def|unless|if|else|elsif|case|when|begin|rescue|ensure|for|while|until|(?=.*?\b(do|begin|case|if|unless)\b)("(\\.|[^\\"])*"|'(\\.|[^\\'])*'|[^#"'])*(\s(do|begin|case)|[-+=&|*/~%^<>~]\s*(if|unless)))\b(?![^;]*;.*?\bend\b)|("(\\.|[^\\"])*"|'(\\.|[^\\'])*'|[^#"'])*(\((?![^\)]*\))|\{(?![^\}]*\})|\[(?![^\]]*\]))).*$/,
+			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
 		},
 		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/
 	});


### PR DESCRIPTION
Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)

Couldn't figure out how to handle indentation in some edge cases so I thought I would try to port Atoms indent pattern to VSCode since I've never had issues when working in Atom.

Well for some reason just copy pasting their indent pattern didn't work so I spent a couple of hours understanding and tweaking it. So this is the result.

Now indentation handles all these cases as expected:
![image](https://user-images.githubusercontent.com/14080148/35470890-00ae9a92-035a-11e8-8c3e-f5fbd8e82f76.png)

---

I won't bother explaining what exactly wasn't working and is working with this PR cause there is a lot of stuff. Well one thing would be that it wouldn't indent after:
```rb
describe "#some_method" do
```
because it saw a `#` inside the string and thought it was a comment.

---
Point is. Everything works as expected now (everything I tested, that is). Also here's the RegExp in a more readable format:

```
(?x)^
(\s*
    (
        module | class
        | ((private | protected)\s+)?def
        | unless | if | else | elsif
        | case | when
        | begin | rescue | ensure
        | for | while | until
        | [^#]+ (?= .*? \b(do|begin|case|if|unless)\b )
        (
            "(\\.|[^\\"])*"            # match double quoted string
            | '(\\.|[^\\'])*'          # match single quoted string
            | [^#"']                   # match everything but comments and strings
        )*
        (
            \s (do | begin | case)
            | [-+=&|*/~%^<>~] \s*+ (if | unless)
        )
    )\b
    (?![^;]*;.*?\bend\b)
    | (
        "(\\.|[^\\"])*"            # match double quoted string
        | '(\\.|[^\\'])*'          # match single quoted string
        | [^#"']                   # match everything but comments and strings
    )*
    ( \( (?! [^\)]* \) )      # paranthesis
    | \{ (?! [^\}]* \} )      # braces
    | \[ (?! [^\]]* \] )      # brackets
)).*$
```

I tested this on vscode-ruby 0.15 cause 0.16 seems to be completely broken, like legit nothing from the package loads into the editor.