### PR TITLE
Add support for Gemfile grammar

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,7 +298,6 @@
           "brewfile",
           "capfile",
           "fastfile",
-          "gemfile",
           "guardfile",
           "podfile",
           "puppetfile",
@@ -322,6 +321,18 @@
           ".rhtm"
         ],
         "configuration": "./language-configuration-erb.json"
+      },
+      {
+        "id": "gemfile",
+        "aliases": [
+          "Gemfile",
+          "Bundler",
+          "bundler"
+        ],
+        "filenames": [
+          "Gemfile"
+        ],
+        "configuration": "./language-configuration-ruby.json"
       }
     ],
     "grammars": [
@@ -334,6 +345,11 @@
         "language": "erb",
         "scopeName": "text.html.erb",
         "path": "./syntaxes/erb.cson.json"
+      },
+      {
+        "language": "gemfile",
+        "scopeName": "source.ruby.gemfile",
+        "path": "./syntaxes/gemfile.cson.json"
       }
     ],
     "debuggers": [

--- a/syntaxes/gemfile.cson.json
+++ b/syntaxes/gemfile.cson.json
@@ -1,0 +1,33 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/atom/language-ruby/blob/master/grammars/gemfile.cson",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/atom/language-ruby/commit/3cb25d88e1173a29027eb52259415a3f851b8662",
+	"name": "Gemfile",
+	"scopeName": "source.ruby.gemfile",
+	"fileTypes": [
+		"Gemfile"
+	],
+	"patterns": [
+		{
+			"include": "source.ruby"
+		},
+		{
+			"begin": "\\b(?<!\\.|::)(gem|git|group|platforms|ruby|source)\\b(?![?!])",
+			"captures": {
+				"1": {
+					"name": "keyword.other.special-method.ruby.gemfile"
+				}
+			},
+			"end": "$|(?=#|})",
+			"name": "meta.declaration.ruby.gemfile",
+			"patterns": [
+				{
+					"include": "$self"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Gemfiles are parsed like ruby but have should support different
highlighting (eg the keyword gem should highlight in a Gemfile but
probably not in normal Ruby). This grammar enables this difference.

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)