### PR TITLE
Add `ruby.intellisense` configuration option

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,12 @@
           "default": "solargraph",
           "description": "Method to use for code completion."
         },
+        "ruby.intellisense": {
+          "type": "string",
+          "enum": ["solargraph", "rubyLocate", "none"],
+          "default": "solargraph",
+          "description": "Method to use for intellisense (go to definition, etc.)."
+        },
         "ruby.rctComplete.commandPath": {
           "type": "string",
           "default": "rct-complete",

--- a/readme.md
+++ b/readme.md
@@ -126,7 +126,21 @@ To enable method completion in Ruby, run `gem install solargraph` or `gem instal
 
 For more information about using Solargraph, refer to the [Solargraph extension](https://marketplace.visualstudio.com/items?itemName=castwide.solargraph).
 
-## Go to definition
+## Intellisense (Go to/Peek Definition)
+
+Use the `ruby.intellisense` setting to select a `go to/peek definition` method. Valid options are `solargraph`, `rubyLocate`, and `none`.
+
+### Solargraph Intellisense
+
+Make sure the solargraph gem installed:
+
+```
+gem install solargraph
+```
+
+Solargraph's features now extend to providing go to/peek definition. See the [Solargraph extension](https://marketplace.visualstudio.com/items?itemName=castwide.solargraph) for more information.
+
+### RubyLocate Intellisense
 
 Now includes workspace parsing functionality. Allows VS Code to `go to definition` and `peak definition` for modules, classes, and methods defined within the same workspace. You can set glob patterns to match including and excluding particular files. The exclude match also runs against directories on initial load, to reduce latency.
 

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -27,7 +27,9 @@ export function activate(context: ExtensionContext) {
 		registerCompletionProvider(context);
 	}
 	registerFormatter(context);
-	registerIntellisenseProvider(context);
+	if (vscode.workspace.getConfiguration('ruby').intellisense == 'rubyLocate') {
+		registerIntellisenseProvider(context);
+	}
 	registerTaskProvider(context);
 	utils.loadEnv();
 }


### PR DESCRIPTION
- [x] Build pass!
- [X] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)

This PR adds the `ruby.intellisense` configuration to allow method selection for go to/peek definition similar to `ruby.codeCompletion`. Valid options are `solargraph`, `rubyLocate`, and `none`.
