### PR TITLE
Fixes to ERB comments

### DIFF
--- a/language-configuration-erb.json
+++ b/language-configuration-erb.json
@@ -1,7 +1,6 @@
 {
 	"comments": {
-		"lineComment": "#",
-		"blockComment": ["=begin", "=end"]
+		"blockComment": [ "<%#", "%>" ]
 	},
 	"brackets": [
 		["{", "}"],

--- a/package.json
+++ b/package.json
@@ -354,7 +354,12 @@
       {
         "language": "erb",
         "scopeName": "text.html.erb",
-        "path": "./syntaxes/erb.cson.json"
+        "path": "./syntaxes/erb.cson.json",
+        "embeddedLanguages": {
+          "source.css": "css",
+          "source.js": "javascript",
+          "source.ruby": "ruby"
+        }
       },
       {
         "language": "gemfile",


### PR DESCRIPTION
This PR reverts the changes done in #224 so that commenting in ERB files again works correctly (resolving #255). In addition, it specifies the `embeddedLanguages` key on the ERB language grammar definition that allows VSCode to assign a different language scope for embedded languages. This PR specifies that Ruby, CSS, and JS can be embedded in ERB.

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)