### PR TITLE
Debounce linting to prevent running on every keypress

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,11 @@
           "description": "Path to the rct-complete command.  Set this to an absolute path to select from multiple installed Ruby versions.",
           "isExecutable": true
         },
+        "ruby.lintDebounceTime": {
+          "type": "integer",
+          "default": 500,
+          "description": "Time (ms) to wait after keypress before running enabled linters. Ensures linters are only run when typing has finished and not for every keypress"
+        },
         "ruby.lint": {
           "type": "object",
           "description": "Set individual ruby linters to use",

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,11 @@ Enable each one in your workspace or user settings:
 	"fasterer": true,
 	"debride": true,
 	"ruby-lint": true
-}
+},
+
+// Time (ms) to wait after keypress before running enabled linters. Ensures
+// linters are only run when typing has finished and not for every keypress
+"ruby.lintDebounceTime": 500,
 
 //advanced: set command line options for some linters:
 "ruby.lint": {


### PR DESCRIPTION
I've been having this issue https://github.com/rubyide/vscode-ruby/issues/252 where the linters run after every keypress and cause significant input lag.

This PR makes the linters only run when typing has finished, instead of after each letter.

Before:
![slow_linting](https://user-images.githubusercontent.com/15195419/36074703-c7bbc190-0f3b-11e8-91f1-10339cafaf6c.gif)

After:
![debounced_linting](https://user-images.githubusercontent.com/15195419/36074706-cff540c0-0f3b-11e8-963e-1b7b14b13e62.gif)

EDIT: Updated to include a configuration option for the delay. 