### PR TITLE
support running launch entries without debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -444,6 +444,11 @@
                 "description": "Use `bundle exec` to run rdebug-ide. Enable this option if you have used bundle install --path with rdebug-ide as a bundled gem.",
                 "default": false
               },
+              "pathToRuby": {
+                "type": "string",
+                "description": "Path to the Ruby executable if it is not 'ruby', used to run the program without the debugger (under CTRL+F5)",
+                "default": "ruby"
+              },
               "pathToBundler": {
                 "type": "string",
                 "description": "If you use the `useBunder` option, and `bundle` is not in your path, provide the absolute path to `bundle` (eg. \"/usr/bin/bundle\" )",

--- a/src/debugger/main.ts
+++ b/src/debugger/main.ts
@@ -78,6 +78,8 @@ class RubyDebugSession extends DebugSession {
 	protected setupProcessHanlders() {
 		this.rubyProcess.on('debuggerComplete', () => {
             this.sendEvent(new TerminatedEvent());
+        }).on('debuggerProcessExit', () => {
+            this.sendEvent(new TerminatedEvent());
         }).on('executableOutput', (data: Buffer) => {
             this.sendEvent(new OutputEvent(data.toString(), 'stdout'));
         }).on('executableStdErr', (error: Buffer) => {

--- a/src/debugger/ruby.ts
+++ b/src/debugger/ruby.ts
@@ -13,6 +13,13 @@ var domErrorLocator: any = {};
 
 const ELEMENT_NODE:number = 1; // Node.ELEMENT_NODE
 
+type ExecutableCommandConfiguration = {
+    pathToRuby : string;
+    useBundler : boolean;
+    pathToBundler : string;
+    rdebugIdePath : string;
+};
+
 export class RubyProcess extends EventEmitter {
     private debugSocketClient : net.Socket = null;
     private buffer: string;
@@ -39,6 +46,38 @@ export class RubyProcess extends EventEmitter {
 
     set state(newState: SocketClientState) {
         this._state = newState;
+    }
+
+    public executableCommandConfiguration(args) {
+        let rdebugIdeDefault : string;
+        if (process.platform === 'win32') {
+            rdebugIdeDefault = 'rdebug-ide.bat';
+        }
+        else {
+            rdebugIdeDefault = 'rdebug-ide';
+        }
+
+        let result : ExecutableCommandConfiguration = {
+            pathToRuby: 'ruby',
+            useBundler: false,
+            pathToBundler : 'bundle',
+            rdebugIdePath : rdebugIdeDefault
+        }
+
+        if (args.pathToRuby) {
+            result.pathToRuby = args.pathToRuby;
+        }
+        if (args.useBundler !== undefined) {
+            result.useBundler = args.useBundler;
+        }
+        if (args.pathToBundler) {
+            result.pathToBundler = args.pathToBundler;
+        }
+        if (args.rdebugIdePath) {
+            result.rdebugIdePath = args.rdebugIdePath;
+        }
+
+        return result;
     }
 
     public constructor(mode: Mode, args: any) {
@@ -156,21 +195,32 @@ export class RubyProcess extends EventEmitter {
             this.buffer = "";
         });
 
+        let executableCommandConfiguration = this.executableCommandConfiguration(args);
 
         if (mode == Mode.launch) {
-            var runtimeArgs = ['--evaluation-timeout', '10'];
+            var runtimeArgs : string[];
             var runtimeExecutable: string;
 
-            if (process.platform === 'win32') {
-                runtimeExecutable = 'rdebug-ide.bat';
+            if (args.noDebug) {
+                runtimeExecutable = executableCommandConfiguration.pathToRuby;
+                runtimeArgs = [];
             }
             else {
-                // platform: linux or darwin
-                runtimeExecutable = 'rdebug-ide';
-            }
+                runtimeExecutable = executableCommandConfiguration.rdebugIdePath;
+                runtimeArgs = ['--evaluation-timeout', '10']
 
-            if (args.pathToRDebugIDE && args.pathToRDebugIDE !== 'rdebug-ide'){
-                runtimeExecutable = args.pathToRDebugIDE;
+                if (args.showDebuggerOutput){
+                    runtimeArgs.push('-x');
+                }
+
+                if (args.debuggerPort && args.debuggerPort !== '1234'){
+                    runtimeArgs.push('-p');
+                    runtimeArgs.push(args.debuggerPort);
+                }
+
+                if (args.stopOnEntry){
+                    runtimeArgs.push('--stop');
+                }
             }
 
             var processCwd = args.cwd || dirname(args.program);
@@ -185,27 +235,10 @@ export class RubyProcess extends EventEmitter {
                 processEnv[env] = args.env[env];
             }
 
-            if (args.showDebuggerOutput){
-                runtimeArgs.push('-x');
-            }
-
-            if (args.debuggerPort && args.debuggerPort !== '1234'){
-                runtimeArgs.push('-p');
-                runtimeArgs.push(args.debuggerPort);
-            }
-
-            if (args.stopOnEntry){
-                runtimeArgs.push('--stop');
-            }
-
-            if (args.useBundler){
+            if (executableCommandConfiguration.useBundler){
                 runtimeArgs.unshift(runtimeExecutable);
                 runtimeArgs.unshift('exec');
-                runtimeExecutable = 'bundle';
-
-                if (args.pathToBundler && args.pathToBundler !== 'bundle'){
-                    runtimeExecutable = args.pathToBundler;
-                }
+                runtimeExecutable = executableCommandConfiguration.pathToBundler;
             }
 
             if (args.includes){
@@ -214,6 +247,7 @@ export class RubyProcess extends EventEmitter {
                     runtimeArgs.push(path)
                 })
             }
+
             // '--' forces process arguments (args.args) not to be swollowed by rdebug-ide
             this.debugprocess = childProcess.spawn(runtimeExecutable, [...runtimeArgs, '--', args.program, ...args.args || []], {cwd: processCwd, env: processEnv});
 


### PR DESCRIPTION
This functionality is mapped to CTRL+F5. When one uses it,
the debugger is instructed to run the program without the
debugger.

To achieve this, the commit adds a pathToRuby configuration
parameter that allows to set which ruby should be used.

Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)