### PR TITLE
add settings to control bundler usage for linters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "Ruby",
-  "version": "0.15.0",
+  "name": "ruby-lang",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,16 @@
           "default": "solargraph",
           "description": "Method to use for intellisense (go to definition, etc.)."
         },
+        "ruby.useBundler": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": "Whether ruby tools should be started using Bundler"
+        },
+        "ruby.pathToBundler": {
+          "type": "string",
+          "default": "bundle",
+          "description": "Path to the bundler executable (used if useBundler is true)"
+        },
         "ruby.rctComplete.commandPath": {
           "type": "string",
           "default": "rct-complete",

--- a/src/lint/lib/linter.js
+++ b/src/lint/lib/linter.js
@@ -59,8 +59,14 @@ class Linter {
 		return fs.link(sourceFile, opName).then(() => opName);
 	}
 	_detectBundledLinter(name, cwd) {
+		let useBundler  = this.cfg[name].useBundler;
+		if (useBundler !== undefined) {
+			return useBundler;
+		}
+
+		let pathToBundler = this.cfg[name].pathToBundler || 'bundle';
 		try {
-			cp.execSync(`bundle show ${name}`, { cwd });
+			cp.execSync(`${pathToBundler} show ${name}`, { cwd });
 			return true;
 		} catch (e) {
 			return false;
@@ -79,7 +85,7 @@ class Linter {
 		// Try bundler for the linter
 		// otherwise fallback to the path + the exe name
 		if (svcPath.length === 0 && this._detectBundledLinter(svc.exe, cmdOpts.dir)) {
-			svcPath = 'bundle';
+			svcPath = this.cfg[svc.exe].pathToBundler;
 			args.unshift('exec', svc.exe);
 		} else {
 			svcPath = path.join(svcPath, svc.exe + svc.ext);

--- a/src/lint/lintCollection.ts
+++ b/src/lint/lintCollection.ts
@@ -2,15 +2,16 @@
 
 const Linter = require('./lib/linter');
 const LintResults = require('./lib/lintResults');
+import { Config } from './lintConfig';
 
 export class LintCollection {
 	private _results: any;
 	private _docLinters: any;
-	private _cfg: any;
+	private _cfg: { [key: string]: Config };
 	private _rootPath: string;
-	private _globalConfig: any;
+	private _globalConfig: Config;
 
-	constructor(globalConfig, lintConfig, rootPath) {
+	constructor(globalConfig : Config, lintConfig : { [key: string]: Config }, rootPath) {
 		this._results = {};
 		this._docLinters = {};
 		this._globalConfig = globalConfig;

--- a/src/lint/lintConfig.ts
+++ b/src/lint/lintConfig.ts
@@ -1,0 +1,8 @@
+export class Config
+{
+	pathToRuby: string = 'ruby';
+	pathToBundler: string = 'bundle';
+	useBundler: boolean | undefined = undefined;
+}
+
+

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -9,6 +9,7 @@ import { LintCollection } from './lint/lintCollection';
 import { RubyDocumentFormattingEditProvider } from './format/rubyFormat';
 import * as utils from './utils';
 import { registerTaskProvider } from './task/rake';
+import { Config as LintConfig } from './lint/lintConfig';
 
 export function activate(context: ExtensionContext) {
 	const subs = context.subscriptions;
@@ -34,11 +35,22 @@ export function activate(context: ExtensionContext) {
 	utils.loadEnv();
 }
 
-function getGlobalConfig() {
-	let globalConfig = {};
-	let rubyInterpreterPath = vscode.workspace.getConfiguration("ruby.interpreter").commandPath;
-	if (rubyInterpreterPath) {
-		globalConfig["rubyInterpreterPath"] = rubyInterpreterPath;
+function getGlobalLintConfig() : LintConfig {
+	let globalConfig = new LintConfig();
+
+	let pathToRuby = vscode.workspace.getConfiguration("ruby.interpreter").commandPath;
+	if (pathToRuby) {
+		globalConfig.pathToRuby = pathToRuby;
+	}
+
+	let useBundler = vscode.workspace.getConfiguration("ruby").get<boolean | null>("useBundler");
+	if (useBundler !== null) {
+		globalConfig.useBundler = useBundler;
+	}
+
+	let pathToBundler = vscode.workspace.getConfiguration("ruby").pathToBundler;
+	if (pathToBundler) {
+		globalConfig.pathToBundler = pathToBundler;
 	}
 	return globalConfig;
 }
@@ -110,7 +122,7 @@ function registerHighlightProvider(ctx: ExtensionContext) {
 }
 
 function registerLinters(ctx: ExtensionContext) {
-	const globalConfig = getGlobalConfig();
+	const globalConfig = getGlobalLintConfig();
 	const linters = new LintCollection(globalConfig, vscode.workspace.getConfiguration("ruby").lint, vscode.workspace.rootPath);
 	ctx.subscriptions.push(linters);
 
@@ -124,7 +136,7 @@ function registerLinters(ctx: ExtensionContext) {
 	ctx.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
 		const docs = vscode.window.visibleTextEditors.map(editor => editor.document);
 		console.log("Config changed. Should lint:", docs.length);
-		const globalConfig = getGlobalConfig();
+		const globalConfig = getGlobalLintConfig();
 		linters.cfg(vscode.workspace.getConfiguration("ruby").lint, globalConfig);
 		docs.forEach(doc => linters.run(doc));
 	}));


### PR DESCRIPTION
The pathToBundler and useBundler settings allow to control whether
and how linters will be using bundler. Not setting useBundler retains
the current auto-detection behavior, but setting it to either true
or false will avoid the call to bundler altogether.

Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)