### PR TITLE
Modify upstream grammar to support optimistic syntax. Resolves #251.

### DIFF
--- a/scripts/meta.function-call.ruby.json
+++ b/scripts/meta.function-call.ruby.json
@@ -1,0 +1,14 @@
+{
+  "begin": "(?=[a-zA-Z0-9_!?]+\\()",
+  "end": "(?<=\\))",
+  "name": "meta.function-call.ruby",
+  "patterns": [
+    { "include": "#nest_function_parens" },
+    { "include": "#known_function_names" },
+    {
+      "match": "([a-zA-Z0-9_!?]+)(?=\\()",
+      "name": "entity.name.function.ruby"
+    },
+    { "include": "$self" }
+  ]
+}

--- a/scripts/update-grammar.js
+++ b/scripts/update-grammar.js
@@ -112,7 +112,6 @@ function getGrammarModifier(grammarName) {
 	switch(grammarName) {
 		case 'ruby':
 			return modifyRubyGrammar;
-			break;
 	}
 }
 

--- a/scripts/update-grammar.js
+++ b/scripts/update-grammar.js
@@ -92,6 +92,30 @@ function getCommitSha(repoId, repoPath) {
 	});
 }
 
+function modifyRubyGrammar(grammar) {
+	const metaFunctionCallRuby = require('./meta.function-call.ruby.json');
+	const variableOtherRuby = require('./variable.other.ruby.json');
+
+	// Replace the constant.other.symbol scope with constant.language.symbol
+	// this is technically incorrect per the docs but a lot of themes do not
+	// have colors defined for constant.other.symbol resulting in users
+	// believing there is no syntax highlighting
+	let stringPatterns = JSON.stringify(grammar.patterns);
+	stringPatterns = stringPatterns.replace(/constant\.other\.symbol/g, 'constant.language.symbol');
+	grammar.patterns = JSON.parse(stringPatterns);
+
+	// Insert meta.function-call.ruby and variable.other.ruby at end
+	grammar.patterns.push(metaFunctionCallRuby, variableOtherRuby);
+}
+
+function getGrammarModifier(grammarName) {
+	switch(grammarName) {
+		case 'ruby':
+			return modifyRubyGrammar;
+			break;
+	}
+}
+
 exports.update = function (repoId, repoPath, dest, modifyGrammar, version = 'master') {
 	var contentPath = 'https://raw.githubusercontent.com/' + repoId + `/${version}/` + repoPath;
 	console.log('Reading from ' + contentPath);
@@ -145,5 +169,5 @@ if (path.basename(process.argv[1]).indexOf('update-grammar') !== -1) {
 	let grammar = process.argv[3];
 	let outputFile = path.join('syntaxes', grammar + '.cson.json');
 	let repoFile = grammarToTmLanguage(grammar);
-	exports.update(repo, repoFile, outputFile);
+	exports.update(repo, repoFile, outputFile, getGrammarModifier(grammar));
 }

--- a/scripts/variable.other.ruby.json
+++ b/scripts/variable.other.ruby.json
@@ -1,0 +1,7 @@
+{
+  "comment":
+    "This is kindof experimental. There really is no way to perfectly match all regular variables, but you can pretty well assume that any normal word in certain curcumstances that havnt already been scoped as something else are probably variables, and the advantages beat the potential errors",
+  "match":
+    "((?<=\\W)\\b|^)\\w+\\b(?=\\s*([\\]\\)\\}\\=\\+\\-\\*\\/\\^\\$\\,\\.]|<\\s|<<[\\s|\\.]))",
+  "name": "variable.other.ruby"
+}

--- a/syntaxes/ruby.cson.json
+++ b/syntaxes/ruby.cson.json
@@ -115,7 +115,7 @@
 			},
 			"comment": "symbols as hash key (1.9 syntax)",
 			"match": "(?>[a-zA-Z_]\\w*(?>[?!])?)(:)(?!:)",
-			"name": "constant.other.symbol.hashkey.ruby"
+			"name": "constant.language.symbol.hashkey.ruby"
 		},
 		{
 			"captures": {
@@ -125,7 +125,7 @@
 			},
 			"comment": "symbols as hash key (1.8 syntax)",
 			"match": "(?<!:)(:)(?>[a-zA-Z_]\\w*(?>[?!])?)(?=\\s*=>)",
-			"name": "constant.other.symbol.hashkey.ruby"
+			"name": "constant.language.symbol.hashkey.ruby"
 		},
 		{
 			"comment": "everything being a reserved word, not a value and needing a 'end' is a..",
@@ -277,7 +277,7 @@
 									"name": "storage.type.variable.ruby"
 								},
 								"2": {
-									"name": "constant.other.symbol.hashkey.parameter.function.ruby"
+									"name": "constant.language.symbol.hashkey.parameter.function.ruby"
 								},
 								"3": {
 									"name": "punctuation.definition.constant.hashkey.ruby"
@@ -319,7 +319,7 @@
 									"name": "storage.type.variable.ruby"
 								},
 								"2": {
-									"name": "constant.other.symbol.hashkey.parameter.function.ruby"
+									"name": "constant.language.symbol.hashkey.parameter.function.ruby"
 								},
 								"3": {
 									"name": "punctuation.definition.constant.hashkey.ruby"
@@ -368,7 +368,7 @@
 					"name": "punctuation.definition.symbol.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"match": "\\\\['\\\\]",
@@ -390,7 +390,7 @@
 					"name": "punctuation.section.symbol.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.interpolated.ruby",
+			"name": "constant.language.symbol.interpolated.ruby",
 			"patterns": [
 				{
 					"include": "#interpolated_ruby"
@@ -619,7 +619,7 @@
 					"name": "punctuation.section.array.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.interpolated.ruby",
+			"name": "constant.language.symbol.interpolated.ruby",
 			"patterns": [
 				{
 					"include": "#interpolated_ruby"
@@ -645,7 +645,7 @@
 					"name": "punctuation.section.array.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.interpolated.ruby",
+			"name": "constant.language.symbol.interpolated.ruby",
 			"patterns": [
 				{
 					"include": "#interpolated_ruby"
@@ -671,7 +671,7 @@
 					"name": "punctuation.section.array.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.interpolated.ruby",
+			"name": "constant.language.symbol.interpolated.ruby",
 			"patterns": [
 				{
 					"include": "#interpolated_ruby"
@@ -697,7 +697,7 @@
 					"name": "punctuation.section.array.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.interpolated.ruby",
+			"name": "constant.language.symbol.interpolated.ruby",
 			"patterns": [
 				{
 					"include": "#interpolated_ruby"
@@ -723,7 +723,7 @@
 					"name": "punctuation.section.array.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.interpolated.ruby",
+			"name": "constant.language.symbol.interpolated.ruby",
 			"patterns": [
 				{
 					"include": "#interpolated_ruby"
@@ -746,7 +746,7 @@
 					"name": "punctuation.section.array.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"match": "\\\\]|\\\\\\\\",
@@ -770,7 +770,7 @@
 					"name": "punctuation.section.array.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"match": "\\\\\\)|\\\\\\\\",
@@ -794,7 +794,7 @@
 					"name": "punctuation.section.array.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"match": "\\\\>|\\\\\\\\",
@@ -818,7 +818,7 @@
 					"name": "punctuation.section.array.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"match": "\\\\}|\\\\\\\\",
@@ -842,7 +842,7 @@
 					"name": "punctuation.section.array.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"comment": "Cant be named because its not neccesarily an escape.",
@@ -1374,7 +1374,7 @@
 					"name": "punctuation.definition.symbol.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"match": "\\\\\\)|\\\\\\\\",
@@ -1398,7 +1398,7 @@
 					"name": "punctuation.definition.symbol.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"match": "\\\\>|\\\\\\\\",
@@ -1422,7 +1422,7 @@
 					"name": "punctuation.definition.symbol.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"match": "\\\\]|\\\\\\\\",
@@ -1446,7 +1446,7 @@
 					"name": "punctuation.definition.symbol.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"match": "\\\\}|\\\\\\\\",
@@ -1470,7 +1470,7 @@
 					"name": "punctuation.definition.symbol.end.ruby"
 				}
 			},
-			"name": "constant.other.symbol.ruby",
+			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
 					"comment": "Cant be named because its not neccesarily an escape.",
@@ -1486,7 +1486,7 @@
 			},
 			"comment": "symbols",
 			"match": "(?x)\n(?<!:)(:)\n(?>\n  [$a-zA-Z_]\\w*(?>[?!]|=(?![>=]))?\n  |\n  ===?|<=>|>[>=]?|<[<=]?|[%&`/\\|]|\\*\\*?|=?~|[-+]@?|\\[]=?\n  |\n  @@?[a-zA-Z_]\\w*\n)",
-			"name": "constant.other.symbol.ruby"
+			"name": "constant.language.symbol.ruby"
 		},
 		{
 			"begin": "^=begin",
@@ -2179,6 +2179,31 @@
 		{
 			"match": "\\(|\\)",
 			"name": "punctuation.section.function.ruby"
+		},
+		{
+			"begin": "(?=[a-zA-Z0-9_!?]+\\()",
+			"end": "(?<=\\))",
+			"name": "meta.function-call.ruby",
+			"patterns": [
+				{
+					"include": "#nest_function_parens"
+				},
+				{
+					"include": "#known_function_names"
+				},
+				{
+					"match": "([a-zA-Z0-9_!?]+)(?=\\()",
+					"name": "entity.name.function.ruby"
+				},
+				{
+					"include": "$self"
+				}
+			]
+		},
+		{
+			"comment": "This is kindof experimental. There really is no way to perfectly match all regular variables, but you can pretty well assume that any normal word in certain curcumstances that havnt already been scoped as something else are probably variables, and the advantages beat the potential errors",
+			"match": "((?<=\\W)\\b|^)\\w+\\b(?=\\s*([\\]\\)\\}\\=\\+\\-\\*\\/\\^\\$\\,\\.]|<\\s|<<[\\s|\\.]))",
+			"name": "variable.other.ruby"
 		}
 	],
 	"repository": {


### PR DESCRIPTION
The original syntax highlighting was based on an "optimistic" syntax highlighting grammar. This change allows us to continue to use the upstream Atom grammar but will insert the correct grammar scopes to still support the optimistic highlighting.

See [here](https://github.com/rubyide/vscode-ruby/issues/251#issuecomment-363093172) for information on what these scopes mean and why.

Note that I could not discover a way to support `constant.other.symbol` and `constant.language.symbol` at the same time. This means Ruby symbols will be highlighted the same as core language constants (like `nil`). In reality this is probably ok as most themes with explicit support appear to map the same color to both types.

Before:
<img width="625" alt="syntax_highlighting_before" src="https://user-images.githubusercontent.com/46283/36933929-8f83f744-1e9e-11e8-96d8-6fb106679167.png">

After:
<img width="625" alt="syntax_highlighting_after" src="https://user-images.githubusercontent.com/46283/36933931-94e85022-1e9e-11e8-81f4-0b46a4baf0b4.png">
