### PR TITLE
add --force-exclusion flag to reek options

### DIFF
--- a/src/lint/lib/linters/reek.js
+++ b/src/lint/lib/linters/reek.js
@@ -6,7 +6,7 @@ function Reek(opts) {
 	this.path = opts.path;
 	this.responsePath = "stdout";
 	this.errorPath = "stderr";
-	this.args = ["-f", "json"];
+	this.args = ["-f", "json", "--force-exclusion"];
 }
 
 Reek.prototype.processResult = function(data) {


### PR DESCRIPTION
Force excluding files specified in the configuration `exclude_paths` even if they are explicitly passed as arguments.

Resolves problem with exclude_paths in the `.reek` config being ignored since we run reek on single files rather than the whole project.

Example that now works after this PR.

```yaml
exclude_paths:
  - db/migrate
```

Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)