### PR TITLE
Add tslint/prettier for linting/formatting.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "useTabs": true
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["esbenp.prettier-vscode", "eg2.tslint"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,11 @@
 	"files.trimTrailingWhitespace": true,
 	"eslint.enable": false,
 	"editor.insertSpaces": false,
+	"[javascript]": {
+		"editor.formatOnSave": true
+	},
+	"[typescript]": {
+		"editor.formatOnSave": true
+	},
 	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3042,6 +3042,15 @@
       "integrity": "sha512-WghvT/oYVV6UGhkHyAVUjcJYmqnYJgw8nfYOmsnTeBdpNeyPfhQTwZ+qa63cni2VE/6J29VP/7ijWcuaVlVcqg==",
       "dev": true
     },
+    "tslint-microsoft-contrib": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.0.3.tgz",
+      "integrity": "sha512-5AnfTGlfpUzpRHLmoojPBKFTTmbjnwgdaTHMdllausa4GBPya5u36i9ddrTX4PhetGZvd4JUYIpAmgHqVnsctg==",
+      "dev": true,
+      "requires": {
+        "tsutils": "2.22.2"
+      }
+    },
     "tsutils": {
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.22.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "ruby-lang",
-  "version": "1.0.0",
+  "name": "Ruby",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -42,6 +42,15 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
@@ -129,6 +138,17 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -193,6 +213,12 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
     "caseless": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
@@ -244,6 +270,21 @@
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "combined-stream": {
@@ -431,6 +472,18 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "event-stream": {
       "version": "3.3.4",
@@ -1696,6 +1749,22 @@
         }
       }
     },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -2352,6 +2421,12 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
+    "prettier": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
+      "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
+      "dev": true
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -2715,6 +2790,12 @@
         "through": "2.3.8"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
@@ -2884,6 +2965,90 @@
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
         "punycode": "1.4.1"
+      }
+    },
+    "tslib": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.2",
+        "commander": "2.12.2",
+        "diff": "3.5.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.11.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.9.0",
+        "tsutils": "2.22.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "tslint-config-prettier": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.10.0.tgz",
+      "integrity": "sha512-WghvT/oYVV6UGhkHyAVUjcJYmqnYJgw8nfYOmsnTeBdpNeyPfhQTwZ+qa63cni2VE/6J29VP/7ijWcuaVlVcqg==",
+      "dev": true
+    },
+    "tsutils": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.22.2.tgz",
+      "integrity": "sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==",
+      "dev": true,
+      "requires": {
+        "tslib": "1.9.0"
       }
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -578,11 +578,5 @@
         ]
       }
     ]
-  },
-  "prettier": {
-    "printWidth": 100,
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "useTabs": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,10 @@
     "gulp-typescript": "^2.12.0",
     "gulp-util": "^3.0.5",
     "mocha": "^2.4.5",
+    "prettier": "^1.11.1",
     "run-sequence": "*",
+    "tslint": "^5.9.1",
+    "tslint-config-prettier": "^1.10.0",
     "typescript": "^2.1.5",
     "vscode": "^1.1.4",
     "vscode-debugadapter-testsupport": "^1.19.0"
@@ -135,13 +138,21 @@
         },
         "ruby.codeCompletion": {
           "type": "string",
-          "enum": ["solargraph", "rcodetools", "none"],
+          "enum": [
+            "solargraph",
+            "rcodetools",
+            "none"
+          ],
           "default": "solargraph",
           "description": "Method to use for code completion."
         },
         "ruby.intellisense": {
           "type": "string",
-          "enum": ["solargraph", "rubyLocate", "none"],
+          "enum": [
+            "solargraph",
+            "rubyLocate",
+            "none"
+          ],
           "default": "solargraph",
           "description": "Method to use for intellisense (go to definition, etc.)."
         },
@@ -567,5 +578,11 @@
         ]
       }
     ]
+  },
+  "prettier": {
+    "printWidth": 100,
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "useTabs": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "run-sequence": "*",
     "tslint": "^5.9.1",
     "tslint-config-prettier": "^1.10.0",
+    "tslint-microsoft-contrib": "^5.0.3",
     "typescript": "^2.1.5",
     "vscode": "^1.1.4",
     "vscode-debugadapter-testsupport": "^1.19.0"

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,7 @@
+{
+	"defaultSeverity": "error",
+	"extends": ["tslint:recommended", "tslint-config-prettier"],
+	"jsRules": {},
+	"rules": {},
+	"rulesDirectory": []
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,12 @@
 {
-	"defaultSeverity": "error",
-	"extends": ["tslint:recommended", "tslint-config-prettier"],
+	"defaultSeverity": "warning",
+	"extends": ["tslint-microsoft-contrib", "tslint-config-prettier"],
 	"jsRules": {},
-	"rules": {},
+	"rules": {
+		"missing-jsdoc": false,
+		"no-backbone-get-outside-model": false,
+		"no-backbone-get-set-outside-model": false,
+		"no-relative-imports": false
+	},
 	"rulesDirectory": []
 }


### PR DESCRIPTION
This change adds tslint & prettier as dev dependencies and recommends the vscode extensions as well. Using tslint will increase the quality of our work with very little dev cost. Prettier will auto-format our js and ts files on save. This sidesteps all problems related to code formatting, since prettier will just take care of it for us.

There are no code changes in this PR. Once this is merged, we should go ahead and run tslint and prettier across the entire source tree as a single PR. Otherwise we'll suffer through piecemeal diffs for subsequent PRs.

If we agree that this is a step we'd like to take, please read the proposed `.prettierrc` below. You can see the full list of options here:

https://prettier.io/docs/en/options.html

Personally I don't care very much about the specific prettier settings. That's the great thing about adopting prettier - using it helps you stop caring about formatting. :)