### PR TITLE
Update Readme.md to fix version of debase gem

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ In this extension, we implement [ruby debug ide protocol](http://debug-commons.r
 - If you are using Ruby v1.9.x (`ruby_19`, `mingw_19`), run `gem install ruby-debug-ide`, the latest version is `0.6.0`. Make sure `ruby-debug-base19x` is installed together with `ruby-debug-ide`.
 - If you are using Ruby v2.x
   * `gem install ruby-debug-ide -v 0.6.0`
-  * `gem install debase -v 0.2.2.beta10` or higher versions
+  * `gem install debase -v 0.2.2` or higher versions
 
 ### Add VS Code config to your project
 Go to the debugger view of VS Code and hit the gear icon. Choose Ruby or Ruby Debugger from the prompt window, then you'll get the sample launch config in `.vscode/launch.json`. The sample launch configurations include debuggers for RSpec (complete, and active spec file) and Cucumber runs. These examples expect that `bundle install --binstubs` has been called.


### PR DESCRIPTION
Debase 0.2.2 was released a few days ago and supports ruby 2.5.1