### PR TITLE
readme.md: Removed explicit gem versions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,11 +48,11 @@ might shed some light on why a gem dependency isn't working.
 ### Install Ruby Dependencies
 In this extension, we implement [ruby debug ide protocol](http://debug-commons.rubyforge.org/protocol-spec.html) to allow VS Code to communicate with ruby debug, it requires `ruby-debug-ide` to be installed on your machine. This is also how RubyMine/NetBeans does by default.
 
-- If you are using JRuby or Ruby v1.8.x (`jruby`, `ruby_18`, `mingw_18`), run `gem install ruby-debug-ide`, the latest version is `0.6.0`
-- If you are using Ruby v1.9.x (`ruby_19`, `mingw_19`), run `gem install ruby-debug-ide`, the latest version is `0.6.0`. Make sure `ruby-debug-base19x` is installed together with `ruby-debug-ide`.
+- If you are using JRuby or Ruby v1.8.x (`jruby`, `ruby_18`, `mingw_18`), run `gem install ruby-debug-ide`.
+- If you are using Ruby v1.9.x (`ruby_19`, `mingw_19`), run `gem install ruby-debug-ide`. Make sure `ruby-debug-base19x` is installed together with `ruby-debug-ide`.
 - If you are using Ruby v2.x
-  * `gem install ruby-debug-ide -v 0.6.0`
-  * `gem install debase -v 0.2.2` or higher versions
+  * `gem install ruby-debug-ide`
+  * `gem install debase`
 
 ### Add VS Code config to your project
 Go to the debugger view of VS Code and hit the gear icon. Choose Ruby or Ruby Debugger from the prompt window, then you'll get the sample launch config in `.vscode/launch.json`. The sample launch configurations include debuggers for RSpec (complete, and active spec file) and Cucumber runs. These examples expect that `bundle install --binstubs` has been called.

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ In this extension, we implement [ruby debug ide protocol](http://debug-commons.r
 - If you are using Ruby v1.9.x (`ruby_19`, `mingw_19`), run `gem install ruby-debug-ide`. Make sure `ruby-debug-base19x` is installed together with `ruby-debug-ide`.
 - If you are using Ruby v2.x
   * `gem install ruby-debug-ide`
-  * `gem install debase`
+  * `gem install debase` (or `gem install byebug`)
 
 ### Add VS Code config to your project
 Go to the debugger view of VS Code and hit the gear icon. Choose Ruby or Ruby Debugger from the prompt window, then you'll get the sample launch config in `.vscode/launch.json`. The sample launch configurations include debuggers for RSpec (complete, and active spec file) and Cucumber runs. These examples expect that `bundle install --binstubs` has been called.


### PR DESCRIPTION
It feels they aren't needed now that you get the right versions with a plain gem install, and it also makes the readme more easily be outdated if keep them here.

Here are the current versions I got when running `gem install`:

```shell
$ gem install ruby-debug-ide
Fetching: ruby-debug-ide-0.6.1.gem (100%)
Building native extensions. This could take a while...
Successfully installed ruby-debug-ide-0.6.1
Parsing documentation for ruby-debug-ide-0.6.1
Installing ri documentation for ruby-debug-ide-0.6.1
Done installing documentation for ruby-debug-ide after 0 seconds
1 gem installed
$ gem install debase
Building native extensions. This could take a while...
Successfully installed debase-0.2.2
Parsing documentation for debase-0.2.2
Installing ri documentation for debase-0.2.2
Done installing documentation for debase after 0 seconds
1 gem installed
```

Make sure these boxes are checked before submitting your PR -- thanks in advance!

- [] Build pass!
- [] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)