### PR TITLE
Only override paths when file actually exists within the cwd/remoteRoot

### DIFF
--- a/src/debugger/main.ts
+++ b/src/debugger/main.ts
@@ -293,36 +293,44 @@ class RubyDebugSession extends DebugSession {
         return localPath.replace(/\\/g, '/');
     }
 
-	protected convertClientPathToDebugger(localPath: string): string {
-		if (this.debugMode == Mode.launch) {
-			return localPath;
-		}
+    protected convertClientPathToDebugger(localPath: string): string {
+        if (this.debugMode == Mode.launch) {
+            return localPath;
+        }
 
-		var relativePath = path.join(
-			this.requestArguments.remoteWorkspaceRoot, localPath.substring(this.requestArguments.cwd.length)
-		);
+        if (!localPath.startsWith(this.requestArguments.cwd)) {
+            return localPath;
+        }
 
-		var sepIndex = this.requestArguments.remoteWorkspaceRoot.lastIndexOf('/');
+        var relativePath = path.join(
+            this.requestArguments.remoteWorkspaceRoot, localPath.substring(this.requestArguments.cwd.length)
+        );
 
-		if (sepIndex !== -1) {
-			// *inx or darwin
-			relativePath = relativePath.replace(/\\/g, '/');
-		}
+        var sepIndex = this.requestArguments.remoteWorkspaceRoot.lastIndexOf('/');
 
-		return relativePath;
-	}
+        if (sepIndex !== -1) {
+            // *inx or darwin
+            relativePath = relativePath.replace(/\\/g, '/');
+        }
 
-	protected convertDebuggerPathToClient(serverPath: string):string{
-		if (this.debugMode == Mode.launch) {
-			return serverPath;
-		}
+        return relativePath;
+    }
 
-		// Path.join will convert the path using local OS preferred separator
-		var relativePath = path.join(
-			this.requestArguments.cwd, serverPath.substring(this.requestArguments.remoteWorkspaceRoot.length)
-		);
-		return relativePath;
-	}
+    protected convertDebuggerPathToClient(serverPath: string):string{
+        if (this.debugMode == Mode.launch) {
+            return serverPath;
+        }
+
+        if (!serverPath.startsWith(this.requestArguments.remoteWorkspaceRoot)) {
+            return serverPath;
+        }
+
+        // Path.join will convert the path using local OS preferred separator
+        var relativePath = path.join(
+            this.requestArguments.cwd, serverPath.substring(this.requestArguments.remoteWorkspaceRoot.length)
+        );
+        return relativePath;
+    }
 
     protected switchFrame(frameId) {
         if (frameId === this._frameId) return;

--- a/src/locate/locate.js
+++ b/src/locate/locate.js
@@ -60,7 +60,7 @@ function filter(symbols, query, matcher) {
 		.uniq()
 		.value();
 }
-module.exports = class Locate {
+export class Locate {
 	constructor(root, settings) {
 		this.settings = settings;
 		this.root = root;

--- a/src/providers/intellisense.ts
+++ b/src/providers/intellisense.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ExtensionContext, SymbolKind, SymbolInformation } from 'vscode';
-import * as Locate from '../locate/locate';
+import { Locate } from '../locate/locate';
 
 export function registerIntellisenseProvider(ctx: ExtensionContext) {
 	// for locate: if it's a project, use the root, othewise, don't bother


### PR DESCRIPTION
This fix improves the ability to debug when running inside of containers and enhances the ability to debug installed gems that do not exist within the workspace root.

Right now I have a hack that will symlink my system installed gems path within my workspace under `tmp/bundle` which I then overlay with a gem cache volume, I then use that same path as my GEM_HOME within the container so that I am able to step into gems, this is required because currently all paths are blindly prefixed with the cwd/remoteRoot.

This change means that if the file exists under say ~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0, it will leave the path alone and not perform the path prefixing upon converting to and from client/debugger paths. Then when running my container I can ensure the in container gems are installed to the same path and stepping into gems just works.

Interestingly it appears that when setting breakpoints that the full path is not as important and if the last few path segments match it will still work but I made the change to `convertClientPathToDebugger` for consistency.

I plan to look at if we can have the same flexibility when mapping back to the client side which would mean not needing to override GEM_HOME within the container further decreasing the barrier to entry, but for now this fix gets the ball rolling.


- [X] Build pass!
- [X] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)