### PR TITLE
Include trailing `?` in ERB when `getWordRangeAtPosition()` used

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -22,6 +22,7 @@ let client;
 export function activate(context: ExtensionContext): void {
 	// register language config
 	languages.setLanguageConfiguration('ruby', languageConfiguration);
+	languages.setLanguageConfiguration('erb', languageConfiguration);
 
 	if (workspace.getConfiguration('ruby').useLanguageServer) {
 		client = require('../client/out/extension');


### PR DESCRIPTION
Fix a bug where calling `getWordRangeAtPosition()` in ERB files omits the trailing `?`.

Fix a bug where calling `getWordRangeAtPosition()` in ERB files omits the trailing `?` by using the same `wordPattern` as Ruby.

The bug has the effect of breaking "Go to Definition" for lookups like `enabled?` when _not_ using `rubyLocate` (ex. [ctagsx](https://github.com/jtanx/ctagsx)).