### PR TITLE
fix docs to reflect how to lint with rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Settings available (in your VSCode workspace) for each of the linters:
 	"rails": true //Run extra rails cops
 }
 ```
+
 ## Formatting
 
 The VS Code Ruby extension can automatically format your Ruby files whenever you save.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ Enable each one in your workspace or user settings:
 	},
 	"rubocop": {
 		"only": ["SpaceInsideBlockBraces", "LeadingCommentSpace"],
-		"lint": true,
 		"rails": true
 	},
 	"reek": true
@@ -148,7 +147,6 @@ Settings available (in your VSCode workspace) for each of the linters:
 }
 
 "rubocop": {
-	"lint": true, //enable all lint cops.
 	"only": [/* array: Run only the specified cop(s) and/or cops in the specified departments. */],
 	"except": [/* array: Run all cops enabled by configuration except the specified cop(s) and/or departments. */],
 	"forceExclusion": true, //Add --force-exclusion option


### PR DESCRIPTION
After running through the issues and spending a few hours trying to figure out why rubocop, I came to the following conclusions:

Rubocop linting works if the settings are as follows: 
```
	"rubocop": {
		"only": ["SpaceInsideBlockBraces", "LeadingCommentSpace"],
		"lint": false,
		"rails": false
	},
```
or
```
	"rubocop": {
		"rails": true
	},
```
I am opening this PR so that others can give input, as I could not find the core issue on my own. But, it looks like if `lint: true` is not included in the rubocop settings, linting works as expected. This is consistent the behavior described in #261.

- [] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run