### PR TITLE
Fix rubocop linting files excluded by config

### DIFF
--- a/src/lint/lib/linter.js
+++ b/src/lint/lib/linter.js
@@ -172,7 +172,7 @@ class Linter {
 			return prom.then(final);
 		});
 		const noTmpFileSvc = () => toRun.filter(svc => !svc.tmp).map(svc => this._exeLinter(svc, {
-			dir: sourceDir || this.rootPath,
+			dir: this.rootPath || sourceDir,
 			data: doc.getText(),
 			file: doc.fileName
 		}).then(final));


### PR DESCRIPTION
I was having issues with Rubocop excluding specific files from linter runs and found that the node process that is being spawned is having it's command directory set to the `dirname` of the file being linted instead of the root directory of the project.

I dug around in the source and found commit https://github.com/rubyide/vscode-ruby/commit/2e42d02843d3aa87783053d5fbaaac064e7b8228 which seems to swap the precedence so that the `sourceDir` is used before the `rootPath`.

This flips precedence back so that the `--force-exclusion` will correctly ignore errors for files excluded from Rubocop that are relative to the project root.

**It should be noted I am unsure of the full effect of this change on other linters or why the flip was made in the first place.**

The following is a minimal config I use to run Rubocop file exclusions specified in another gem's config:

```
{
  "ruby.lint": {
    "rubocop": {
      "forceExclusion": true
    }
  },
  "ruby.useBundler": true
}
```

Example `.rubocop.yml` file:

```
inherit_gem:
  rubocop_coffeeandcode:
    - config/default.yml
    - config/rails.yml

inherit_mode:
  merge:
    - Exclude
```