### PR TITLE
Allow for detaching of debugger

### DIFF
--- a/src/debugger/main.ts
+++ b/src/debugger/main.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { workspace } from 'vscode';
 import {DebugSession, InitializedEvent, TerminatedEvent, StoppedEvent, BreakpointEvent, OutputEvent, Thread, StackFrame, Scope, Source, Handles, Breakpoint} from 'vscode-debugadapter';
 import {DebugProtocol} from 'vscode-debugprotocol';
 import {readFileSync,existsSync} from 'fs';
@@ -452,9 +453,11 @@ class RubyDebugSession extends DebugSession {
     }
 
     protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments) {
+        const detachDebugger = workspace.getConfiguration('ruby').detachDebugger && this.debugMode === Mode.attach;
         if (this.rubyProcess.state !== SocketClientState.closed) {
-            this.rubyProcess.Run('quit');
+            this.rubyProcess.Run(detachDebugger ? 'detach' : 'quit');
         }
+
         this.sendResponse(response);
     }
 }

--- a/src/debugger/main.ts
+++ b/src/debugger/main.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { workspace } from 'vscode';
+import {workspace} from 'vscode';
 import {DebugSession, InitializedEvent, TerminatedEvent, StoppedEvent, BreakpointEvent, OutputEvent, Thread, StackFrame, Scope, Source, Handles, Breakpoint} from 'vscode-debugadapter';
 import {DebugProtocol} from 'vscode-debugprotocol';
 import {readFileSync,existsSync} from 'fs';


### PR DESCRIPTION
Building off of #333, I added a settings option `detachDebugger` which will allow a user to chose to just detach instead of quitting a debugging process. This helps to make sure your Rails server doesn't get shut down whenever you quit the debugger.

If/when this PR is merged, I will update the [wiki page](https://github.com/rubyide/vscode-ruby/wiki/3.-Attaching-to-a-debugger) to reflect the new option. 

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run