### PR TITLE
Mark deliverfile as a Ruby file

### DIFF
--- a/package.json
+++ b/package.json
@@ -365,6 +365,7 @@
           "berksfile",
           "brewfile",
           "capfile",
+          "deliverfile",
           "fastfile",
           "guardfile",
           "podfile",


### PR DESCRIPTION
Just like Appfile and Fastfile, Deliverfile is part of the Fastlane toolchain written in Ruby.

See https://docs.fastlane.tools/actions/deliver/

- [ ] The build passes
- [ ] TSLint is mostly happy
- [ ] Prettier has been run

N/A, this was a quick edit in the GitHub editor.