### PR TITLE
Call the async-callback to clear parseQueue of items

### DIFF
--- a/src/locate/locate.js
+++ b/src/locate/locate.js
@@ -67,7 +67,7 @@ export class Locate {
 		this.tree = {};
 		this.walkQueue = this._createWalkQueue();
 		this.walkPromise = null;
-		this.parseQueue = async.queue((task, callback) => task().then(() => callback), SINGLE_FILE_PARSE_CONCURRENCY);
+		this.parseQueue = async.queue((task, callback) => task().then(() => callback()), SINGLE_FILE_PARSE_CONCURRENCY);
 	}
 	listInFile(absPath) {
 		const waitForParse = (absPath in this.tree) ? Promise.resolve() : this.parse(absPath);


### PR DESCRIPTION
Fixes #398

Not calling the callback caused a bug that meant that after a few tasks
were enqueued on the parseQueue (i.e. a few change-/create-events), all
incoming tasks were queued and never executed. That lead to newly added
symbols not being added to the symbols list and the locations of all
symbols after that being off.

- [x] The build passes
- [x] TSLint is mostly happy
- [ ] Prettier has been run