### PR TITLE
Respect ruby.pathToBundler for RuboCop executable

### DIFF
--- a/src/format/RuboCop.ts
+++ b/src/format/RuboCop.ts
@@ -42,7 +42,8 @@ export class AutoCorrect {
 
 		const ext: string = process.platform === 'win32' ? '.bat' : '';
 		if (vscode.workspace.getConfiguration('ruby').useBundler) {
-			let pathToBundler = vscode.workspace.getConfiguration('ruby').pathToBundler || 'bundle';
+			const pathToBundler: string =
+				vscode.workspace.getConfiguration('ruby').pathToBundler || 'bundle';
 			return [`${pathToBundler}${ext}`, 'exec', 'rubocop'];
 		}
 

--- a/src/format/RuboCop.ts
+++ b/src/format/RuboCop.ts
@@ -42,7 +42,8 @@ export class AutoCorrect {
 
 		const ext: string = process.platform === 'win32' ? '.bat' : '';
 		if (vscode.workspace.getConfiguration('ruby').useBundler) {
-			return [`bundle${ext}`, 'exec', 'rubocop'];
+			let pathToBundler = vscode.workspace.getConfiguration('ruby').pathToBundler || 'bundle';
+			return [`${pathToBundler}${ext}`, 'exec', 'rubocop'];
 		}
 
 		return [`rubocop${ext}`];


### PR DESCRIPTION
TL;DR: `src/format/RuboCop.ts` should use `ruby.pathToBundler` configuration when specified.

Since I'm new to vscode extension development, I didn't understand how to add / run tests for vscode extensions. Thanks in advance if anyone helps to improve this PR. 

----

### Environment
- `vscode-ruby` version: 0.20.0
- Ruby version: default 2.4.3, workspace 2.5.1
- Ruby version manager (if any): rvm
- VS Code version: 1.29.1
- Operating System: MacOS High Sierra (10.13.6)
- Using language server? no

### Expected behavior
Use `bundler` to run `AutoCorrect.test()` by `RubyDocumentFormattingEditProvider` from `ruby.pathToBundler` when `ruby.useBundler` is true and `ruby.pathToBundler` is specified.


### Actual behavior
It uses `bundle` from the default path.


### Steps to find the problem
I'm using rvm for ruby version control, and my default version and worksapce version is different.
```
$ rvm ls
 * ruby-2.4.3 [ x86_64 ]
=> ruby-2.5.1 [ x86_64 ]
```

After installed rubocop, I configured my settings as following, to enable lint and auto formatting:
```
"ruby.format": "rubocop",
  "ruby.intellisense": "rubyLocate",
  "ruby.lint": {
    "rubocop": true
  },
  "[ruby]": {
    "editor.formatOnSave": true
  },
  "editor.formatOnSaveTimeout": 5000
```

But both lint and formatting didn't work. It said `rubocop failed with code=7` which I couldn't understand.

After a few searchs, I added custom rubocop path in workspace settings and the lint started working.
```
"ruby.lint": {
    "rubocop": {
      "path": "/Users/ted/.rvm/gems/ruby-2.5.1/wrappers"
    }
  },
```

However, auto formatting never worked, and I found these messages from developer console.
```
[Extension Host] rubocop stderr /Users/ted/.rvm/gems/ruby-2.4.3/gems/bundler-1.17.1/lib/bundler/definition.rb:495:in `validate_ruby!': Your Ruby version is 2.4.3, but your Gemfile specified 2.5.1 (Bundler::RubyVersionMismatch)
	from /Users/ted/.rvm/gems/ruby-2.4.3/gems/bundler-1.17.1/lib/bundler/definition.rb:470:in `validate_runtime!'
	from /Users/ted/.rvm/gems/ruby-2.4.3/gems/bundler-1.17.1/lib/bundler.rb:101:in `setup'
	from /Users/ted/.rvm/gems/ruby-2.4.3/gems/bundler-1.17.1/lib/bundler/setup.rb:20:in `<top (required)>'
	from /Users/ted/.rvm/rubies/ruby-2.4.3/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	from /Users/ted/.rvm/rubies/ruby-2.4.3/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:59:in `require'

notificationsAlerts.ts:40 rubocop failed with code=1
```

So I added another configuration to specify bundler path. but no luck.
```
"ruby.useBundler": true,
"ruby.pathToBundler": "/Users/ted/.rvm/gems/ruby-2.5.1/wrappers/bundle"
```

I finally looked through the source code, and realized that although `src/format/RuboCop.ts` sees the `ruby.useBundler` option, it doesn't utilize `ruby.pathToBundler` to execute `bundle`. (24cb72f)
```
	// What's the exe name for rubocop?
	get exe(): string[] {
		const opts:any = this.opts;
		if (opts.exe) {
			return [opts.exe];
		}

		const ext: string = process.platform === 'win32' ? '.bat' : '';
		if (vscode.workspace.getConfiguration('ruby').useBundler) {
			return [`bundle${ext}`, 'exec', 'rubocop'];
		}

		return [`rubocop${ext}`];
	}
```