### PR TITLE
Fix linter offenses not updating after re-opening a file.

### DIFF
--- a/src/lint/lintCollection.ts
+++ b/src/lint/lintCollection.ts
@@ -23,7 +23,12 @@ export class LintCollection {
 	public run(doc) {
 		if (!doc) return;
 		if (doc.languageId !== 'ruby') return;
-		if (!this._docLinters[doc.fileName]) this._docLinters[doc.fileName] = new Linter(doc, this._rootPath, this._update.bind(this, doc));
+		if (!this._docLinters[doc.fileName] || this._docLinters[doc.fileName].doc != doc)
+			this._docLinters[doc.fileName] = new Linter(
+				doc,
+				this._rootPath,
+				this._update.bind(this, doc)
+			);
 		this._docLinters[doc.fileName].run(this._cfg);
 	}
 


### PR DESCRIPTION
Need to check whether the document provided to the linter is still the
same object as in previous runs. I.e. when closing and re-opening a file,
the document object changes, so the existing linter object won't see
updates to the content anymore.

Fixes #373.