### PR TITLE
Added new option to keep ruby process when disconnect request

### DIFF
--- a/package.json
+++ b/package.json
@@ -685,6 +685,11 @@
 								"type": "boolean",
 								"description": "Show output of the debugger in the console.",
 								"default": false
+							},
+							"keepRubyProcessOnDisconnect": {
+								"type": "boolean",
+								"description": "Keep ruby process on disconnect request.",
+								"default": false
 							}
 						}
 					}

--- a/src/debugger/interface.ts
+++ b/src/debugger/interface.ts
@@ -27,6 +27,8 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
     remoteWorkspaceRoot?: string;
 	/** Show debugger process output. If not specified, there will only be executable output */
     showDebuggerOutput?: boolean;
+    /** Keep ruby process on disconnect request */
+    keepRubyProcessOnDisconnect?: boolean;
 }
 
 export interface IRubyEvaluationResult {

--- a/src/debugger/main.ts
+++ b/src/debugger/main.ts
@@ -452,7 +452,7 @@ class RubyDebugSession extends DebugSession {
     }
 
     protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments) {
-        if (this.rubyProcess.state !== SocketClientState.closed) {
+        if (!this.requestArguments.keepRubyProcessOnDisconnect && this.rubyProcess.state !== SocketClientState.closed) {
             this.rubyProcess.Run('quit');
         }
         this.sendResponse(response);


### PR DESCRIPTION
My team has been using the debugger with Rails, and every time we disconnect the debugger, the extension quits the ruby process, so my rails server go off as well.
We use the extension in some big projects, and it takes some time to start de server again.

This changes will help us a lot, I probably other users as well.

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run