### PR TITLE
Fix automatic Rake task detection.

### DIFF
--- a/src/task/rake.ts
+++ b/src/task/rake.ts
@@ -9,12 +9,12 @@ let rakeFiles: Set<vscode.Uri> = new Set<vscode.Uri>();
 
 export async function registerTaskProvider(ctx: vscode.ExtensionContext) {
 	let rakePromise: Thenable<vscode.Task[]> | undefined = undefined;
-	let files = await vscode.workspace.findFiles("**/[rR]akefile{,.rb}");
+	let files = await vscode.workspace.findFiles("**/[rR]akefile{*,.rb}");
 	for (let i = 0; i < files.length; i++) {
 		rakeFiles.add(files[i]);
 	}
 
-	let fileWatcher = vscode.workspace.createFileSystemWatcher("**/[rR]akefile{,.rb}");
+	let fileWatcher = vscode.workspace.createFileSystemWatcher("**/[rR]akefile{*,.rb}");
 	fileWatcher.onDidChange(() => rakePromise = undefined);
 	fileWatcher.onDidCreate((uri) => {
 		rakeFiles.add(uri);


### PR DESCRIPTION
Previously, the globPattern used in rake.ts was failing to find Rakefiles if they were named `Rakefile, without the `.rb` extension. This fixes the globPattern so now it matches in that case.

This has the downside of also matching any filename that starts with `Rakefile`, e.g. `Rakefile2` or `Rakefileadsadadsad`, but I'm not sure of a great way to fix this without that downside.

If you select `Task: Run Task` in the Command Palette you can see the difference (note the workspace needs to have a file named `Rakefile`, `Rakefile.rb` will be detected without this change).

Before:

<img width="1552" alt="Screen Shot 2019-03-15 at 10 19 23 PM" src="https://user-images.githubusercontent.com/2977353/54470611-68b34880-4770-11e9-99df-5f0b3ec545c0.png">

After:
<img width="1552" alt="Screen Shot 2019-03-15 at 10 15 51 PM" src="https://user-images.githubusercontent.com/2977353/54470588-f8a4c280-476f-11e9-85a2-2058a1685892.png">

This fixes #273.

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run