### PR TITLE
Path manipulation using correct OS path class

### DIFF
--- a/src/debugger/main.ts
+++ b/src/debugger/main.ts
@@ -330,10 +330,10 @@ class RubyDebugSession extends DebugSession {
             return serverPath;
         }
 
-		let remotePathImplementation = this.getPathImplementation(this.requestArguments.remoteWorkspaceRoot);
-		let localPathImplementation = this.getPathImplementation(this.requestArguments.cwd);
+        let remotePathImplementation = this.getPathImplementation(this.requestArguments.remoteWorkspaceRoot);
+        let localPathImplementation = this.getPathImplementation(this.requestArguments.cwd);
 
-		let relativeRemotePath = remotePathImplementation.relative(this.requestArguments.remoteWorkspaceRoot, serverPath)
+        let relativeRemotePath = remotePathImplementation.relative(this.requestArguments.remoteWorkspaceRoot, serverPath)
 
         if (!this.isSubPath(relativeRemotePath)) {
             return serverPath;

--- a/src/debugger/main.ts
+++ b/src/debugger/main.ts
@@ -330,17 +330,15 @@ class RubyDebugSession extends DebugSession {
             return serverPath;
         }
 
-        let relativeRemotePath = path.relative(this.requestArguments.remoteWorkspaceRoot, serverPath)
+		let remotePathImplementation = this.getPathImplementation(this.requestArguments.remoteWorkspaceRoot);
+		let localPathImplementation = this.getPathImplementation(this.requestArguments.cwd);
+
+		let relativeRemotePath = remotePathImplementation.relative(this.requestArguments.remoteWorkspaceRoot, serverPath)
 
         if (!this.isSubPath(relativeRemotePath)) {
             return serverPath;
         }
 
-        let remotePathImplementation = this.getPathImplementation(this.requestArguments.remoteWorkspaceRoot);
-        let localPathImplementation = this.getPathImplementation(this.requestArguments.cwd);
-
-
-        // Path.join will convert the path using local OS preferred separator
         let relativePath = localPathImplementation.join.apply(
             null,
             [this.requestArguments.cwd].concat(

--- a/src/debugger/main.ts
+++ b/src/debugger/main.ts
@@ -354,7 +354,7 @@ class RubyDebugSession extends DebugSession {
 
         let relativePath = localPathImplementation.join.apply(
             null,
-	          [this.requestArguments.cwd].concat(relativeRemotePath.split(remotePathImplementation.sep))
+            [this.requestArguments.cwd].concat(relativeRemotePath.split(remotePathImplementation.sep))
         );
 
         return relativePath;


### PR DESCRIPTION
Allow case insensitive path comparison on Windows.
Fixes path generation when local is Windows and remote is Posix.

I had issue debugging a ruby application running in a Linux docker environment using visual studio code on Windows. The issue seems to have started with VSCode 1.30

It was caused by the drive letter part of the workspace directory being lower case while the letter drive part of a file being upper case, preventing the path conversion to happen.

While debugging I also noticed that on Posix, `path.join` wasn't converting backslashes to slashes, so I changed the join call to handle this case.

- [x] The build passes
- [x] TSLint is mostly happy
- [] Prettier has been run