### PR TITLE
Node Runtime

### DIFF
--- a/client/src/WorkspaceRubyEnvironment.ts
+++ b/client/src/WorkspaceRubyEnvironment.ts
@@ -3,6 +3,7 @@ import {
 	LanguageClient,
 	RequestType,
 	StaticFeature,
+	InitializeParams,
 } from 'vscode-languageclient';
 import { Uri, workspace, WorkspaceFolder } from 'vscode';
 import { loadEnv, IEnvironment } from './util/env';
@@ -33,8 +34,18 @@ type WorkspaceRubyEnvironmentCapability = {
 type ClientCapabilitiesWithRubyEnvironment = ClientCapabilities &
 	WorkspaceRubyEnvironmentCapability;
 
+export enum NodeRuntime {
+	Electron = 1,
+	Node = 2
+}
+
 export class WorkspaceRubyEnvironmentFeature implements StaticFeature {
-	constructor(private client: LanguageClient) {}
+	constructor(private client: LanguageClient, private runtime: NodeRuntime) { }
+
+	public fillInitializeParams(params: InitializeParams): void {
+		params.initializationOptions = params.initializationOptions || {};
+		params.initializationOptions.runtime = this.runtime;
+	}
 
 	public fillClientCapabilities(capabilities: ClientCapabilitiesWithRubyEnvironment): void {
 		capabilities.workspace = capabilities.workspace || {};

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -13,7 +13,7 @@ import {
 	TransportKind,
 	WorkspaceMiddleware,
 } from 'vscode-languageclient';
-import { WorkspaceRubyEnvironmentFeature } from './WorkspaceRubyEnvironment';
+import { WorkspaceRubyEnvironmentFeature, NodeRuntime } from './WorkspaceRubyEnvironment';
 
 const RUBOCOP_ABSOLUTE_PATH_KEYS = ['require'];
 let client: LanguageClient;
@@ -95,7 +95,8 @@ export function activate(context: ExtensionContext): void {
 	// Create the language client and start the client.
 	client = new LanguageClient('ruby', 'Ruby', serverOptions, clientOptions);
 	client.registerProposedFeatures();
-	client.registerFeature(new WorkspaceRubyEnvironmentFeature(client));
+	const nodeRuntime = (context as any).executionContext === 1 ? NodeRuntime.Electron : NodeRuntime.Node;
+	client.registerFeature(new WorkspaceRubyEnvironmentFeature(client, nodeRuntime));
 
 	// Push the disposable to the context's subscriptions so that the
 	// client can be deactivated on extension deactivation

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
@@ -325,7 +325,7 @@
     "coffee-script": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "integrity": "sha1-wF2uDLeVkdBbMHCoQzqYyaiczFM=",
       "dev": true
     },
     "color-convert": {
@@ -387,7 +387,7 @@
     "cson-parser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-2.0.1.tgz",
-      "integrity": "sha512-06Z/arU/l0SMC2UGEGZ7TIz8JLw9fvgD0ItI3tmoNH23Sxt5y9lEdXRN0oaeuXqQV+NBYh4JpsEuNIMxZfMVqA==",
+      "integrity": "sha1-tHQMF8KIDWfLyab2YVtuhvwL6O8=",
       "dev": true,
       "requires": {
         "coffee-script": "^1.10.0"
@@ -667,7 +667,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1231,7 +1231,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from 'vscode-languageserver';
 
 import { ILanguageServer } from './Server';
-import { rebuildTreeSitter } from './util/rebuilder';
+import { rebuildTreeSitter, NodeRuntime } from './util/rebuilder';
 
 const connection: IConnection = createConnection(ProposedFeatures.all);
 let server: ILanguageServer;
@@ -18,8 +18,9 @@ let server: ILanguageServer;
 connection.onInitialize(async (params: InitializeParams) => {
 	connection.console.info('Initializing Ruby language server...');
 
-	connection.console.info('Rebuilding tree-sitter for local Electron version');
-	const rebuildResult: [void | Error, void | Error] = await rebuildTreeSitter();
+	let nodeRuntime = params.initializationOptions ? params.initializationOptions.runtime : NodeRuntime.Electron;
+	connection.console.info(`Rebuilding tree-sitter for local ${nodeRuntime === NodeRuntime.Electron ? 'Electron' : 'Node.js'} version`);
+	const rebuildResult: [void | Error, void | Error] = await rebuildTreeSitter(nodeRuntime);
 	for (const result of rebuildResult) {
 		if (result) {
 			connection.console.error('Rebuild failed!');

--- a/server/src/util/rebuilder.ts
+++ b/server/src/util/rebuilder.ts
@@ -1,6 +1,11 @@
 import * as path from 'path';
 import * as prebuildInstall from 'prebuild-install';
 
+export enum NodeRuntime {
+	Electron = 1,
+	Node = 2
+}
+
 function packageToGithubRepo(name: string): string {
 	let repo: string;
 	switch (name) {
@@ -14,20 +19,20 @@ function packageToGithubRepo(name: string): string {
 	return repo;
 }
 
-function downloadUrl(name: string, version: string): string {
+function downloadUrl(name: string, version: string, nodeRuntime: NodeRuntime): string {
 	const repo: string = packageToGithubRepo(name);
 	const urlBase: string = `https://github.com/tree-sitter/${repo}/releases/download/v${version}/`;
-	const prebuild: string = `${name}-v${version}-electron-v${process.versions.modules}-${
+	const prebuild: string = `${name}-v${version}-${nodeRuntime === NodeRuntime.Electron ? 'electron' : 'node'}-v${process.versions.modules}-${
 		process.platform
-	}-${process.arch}.tar.gz`;
+		}-${process.arch}.tar.gz`;
 
 	return `${urlBase}${prebuild}`;
 }
 
-function fetchPrebuild(name: string): Promise<void | Error> {
+function fetchPrebuild(name: string, nodeRuntime: NodeRuntime): Promise<void | Error> {
 	const pkgRoot: string = path.resolve(path.join(__dirname, '../../node_modules', name));
 	const pkg: { name: string; version: string } = require(`${pkgRoot}/package.json`);
-	const url: string = downloadUrl(pkg.name, pkg.version);
+	const url: string = downloadUrl(pkg.name, pkg.version, nodeRuntime);
 
 	return new Promise((res, rej) => {
 		prebuildInstall.download(url, { pkg, path: pkgRoot }, (err: Error) => {
@@ -36,6 +41,6 @@ function fetchPrebuild(name: string): Promise<void | Error> {
 	});
 }
 
-export function rebuildTreeSitter(): Promise<[void | Error, void | Error]> {
-	return Promise.all([fetchPrebuild('tree-sitter'), fetchPrebuild('tree-sitter-ruby')]);
+export function rebuildTreeSitter(nodeRuntime: NodeRuntime): Promise<[void | Error, void | Error]> {
+	return Promise.all([fetchPrebuild('tree-sitter', nodeRuntime), fetchPrebuild('tree-sitter-ruby', nodeRuntime)]);
 }


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-remote-release/issues/153. 

VS Code released [Remote Development](https://code.visualstudio.com/docs/remote/remote-overview) recently, which allows users to connect VS Code to an isolated remote environment, e.g., ssh box, container or WSL. As remote environment is using Nodejs instead of Electron patched Nodejs, current prebuilt tree sitter binaries won't work properly.

To fix this issue 

* This PR added check for host environment and fetch corresponding prebuilt binaries based on both platform/arch and Node runtime
* `tree-sitter-node` already has prebuilt for Node so we want to do the same thing for `tree-sitter-ruby`, here is the PR for it https://github.com/tree-sitter/tree-sitter-ruby/pull/106