### PR TITLE
Update extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-	"recommendations": ["esbenp.prettier-vscode", "eg2.tslint"]
+	"recommendations": ["esbenp.prettier-vscode", "ms-vscode.vscode-typescript-tslint-plugin"]
 }


### PR DESCRIPTION
eg2.tslint has been deprecated in favour of Microsoft's
`ms-vscode-vscode-typescript-tslint-pugin`

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run