### PR TITLE
Clarify rubocop configuration for 'lint: true'

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Settings available (in your VSCode workspace) for each of the linters:
 }
 
 "rubocop": {
-	"lint": true, //enable all lint cops.
+	"lint": true, //Run only lint cops.
 	"only": [/* array: Run only the specified cop(s) and/or cops in the specified departments. */],
 	"except": [/* array: Run all cops enabled by configuration except the specified cop(s) and/or departments. */],
 	"forceExclusion": true, //Add --force-exclusion option


### PR DESCRIPTION
The `"lint": true` flag on the rubocop configuration for linting runs the rubocop command with the `-l` flag. The rubocop documentation describes this flag with "Run only lint cops". However, the readme here describes the configuration as "enable all lint cops". This discrepancy led myself and some of my co-workers to believe that this configuration was required to enable any lint checks at all, and we were confused as to why many checks were not being performed with this config option set to true. This pr updates the description of the configuration to be more in line with the rubocop documentation.

- [ ] The build passes
- [X] TSLint is mostly happy
- [] Prettier has been run