### PR TITLE
Pass LANG environment variable to language server

### DIFF
--- a/client/src/util/env.ts
+++ b/client/src/util/env.ts
@@ -92,6 +92,7 @@ const RUBY_ENVIRONMENT_VARIABLES = [
 	'GEM_ROOT',
 	'HOME',
 	'RUBOCOP_OPTS',
+	'LANG',
 ];
 
 export interface IEnvironment {


### PR DESCRIPTION
The LANG env variable is needed for rufo, so that it is able to parse ruby files with multibyte characters.
Since it should be available and correct in most Mac and Linux environments we only need to pass the host value.

I tested it and this resolves #493 for me.

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run