### PR TITLE
Add rake task definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -690,6 +690,24 @@
 					}
 				}
 			}
+		],
+		"taskDefinitions": [
+			{
+				"type": "rake",
+				"required": [
+					"task"
+				],
+				"properties": {
+					"task": {
+						"type": "string",
+						"description": "The Rake task to customize"
+					},
+					"file": {
+						"type": "string",
+						"description": "The Rake file that provides the task. Can be omitted."
+					}
+				}
+			}
 		]
 	}
 }


### PR DESCRIPTION
Add missing task definition for rake tasks. This allows some customization of auto-detected tasks (e.g never scan the task output). Without task definition VSCode shows 'Value is not accepted' error and ignores that task.

![image](https://user-images.githubusercontent.com/13588588/60039660-ebc53280-96bf-11e9-9398-7ee1ad185875.png)


- [x] The build passes
- [x] TSLint is mostly happy
- [ ] Prettier has been run