### PR TITLE
Fix bug in locate.js

### DIFF
--- a/src/locate/locate.js
+++ b/src/locate/locate.js
@@ -70,8 +70,10 @@ export class Locate {
 		this.parseQueue = async.queue((task, callback) => task().then(() => callback()), SINGLE_FILE_PARSE_CONCURRENCY);
 	}
 	listInFile(absPath) {
-		const waitForParse = (absPath in this.tree) ? Promise.resolve() : this.parse(absPath);
-		return waitForParse.then(() => _.clone(this.tree[absPath] || []));
+		if (!absPath in this.tree)
+			this.parse(absPath);
+
+		return Promise.resolve(_.clone(this.tree[absPath] || []));
 	}
 	find(name) {
 		return this._waitForWalk().then(() => this._find(name));


### PR DESCRIPTION
I encountered a bug where `absPath in this.tree` was false so `waitForParse` was assigned the value of `this.parse(absParse)`. However, `this.parse(absParse)` does not have a return value so I was getting `TypeError: Cannot read property 'then' of undefined at Locate.listInFile`.

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run