### PR TITLE
Update `decreaseIndentPattern` to match Atom

### DIFF
--- a/src/languageConfiguration.ts
+++ b/src/languageConfiguration.ts
@@ -1,7 +1,7 @@
 const languageConfiguration = {
 	indentationRules: {
 		increaseIndentPattern: /^(\s*(module|class|((private|protected)\s+)?def|unless|if|else|elsif|case|when|begin|rescue|ensure|for|while|until|(?=.*?\b(do|begin|case|if|unless)\b)("(\\.|[^\\"])*"|'(\\.|[^\\'])*'|[^#"'])*(\s(do|begin|case)|[-+=&|*/~%^<>~]\s*(if|unless)))\b(?![^;]*;.*?\bend\b)|("(\\.|[^\\"])*"|'(\\.|[^\\'])*'|[^#"'])*(\((?![^\)]*\))|\{(?![^\}]*\})|\[(?![^\]]*\]))).*$/,
-		decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/,
+		decreaseIndentPattern: /^\s*([}\])](,?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/,
 	},
 	wordPattern: /(-?\d+(?:\.\d+))|([A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/,
 };


### PR DESCRIPTION
Atom's [`decreaseIndentPattern`](https://github.com/atom/language-ruby/blob/d88a4cfb32876295ec5b090a2994957e62130f4a/settings/language-ruby.cson) handles cases like this:

```
@date = Date.today()
@name = "Test Name"

@data = {
  id: 8,
  foo: Foo.new(
    id: 1,
    phone_number: "412-555-7640"
  ),
  bar: Bar.new(
    id: 1,
    name: "Valentine",
    vin: "DF5S6HFG365HGDCVG",
    status: :AVAILABLE
  ),
  start_time: start_time.to_s,
  end_time: end_time.to_s,
  cost: 23.45,
  rating: 3,
}
```