### PR TITLE
Improve/Fix Block Parameter highlighting

### DIFF
--- a/syntaxes/ruby.cson.json
+++ b/syntaxes/ruby.cson.json
@@ -243,7 +243,7 @@
 		},
 		{
 			"match": "\\b[_A-Z]\\w*\\b",
-			"name": ""
+			"name": "variable.other.constant.ruby"
 		},
 		{
 			"begin": "(?x)\n(?=def\\b)                          # optimization to help Oniguruma fail fast\n(?<=^|\\s)(def)\\s+\n(\n  (?>[a-zA-Z_]\\w*(?>\\.|::))?      # method prefix\n  (?>                               # method name\n    [a-zA-Z_]\\w*(?>[?!]|=(?!>))?\n    |\n    ===?|!=|>[>=]?|<=>|<[<=]?|[%&`/\\|]|\\*\\*?|=?~|[-+]@?|\\[]=?\n  )\n)\n\\s*(\\()",

--- a/syntaxes/ruby.cson.json
+++ b/syntaxes/ruby.cson.json
@@ -243,7 +243,7 @@
 		},
 		{
 			"match": "\\b[_A-Z]\\w*\\b",
-			"name": "variable.other.constant.ruby"
+			"name": ""
 		},
 		{
 			"begin": "(?x)\n(?=def\\b)                          # optimization to help Oniguruma fail fast\n(?<=^|\\s)(def)\\s+\n(\n  (?>[a-zA-Z_]\\w*(?>\\.|::))?      # method prefix\n  (?>                               # method name\n    [a-zA-Z_]\\w*(?>[?!]|=(?!>))?\n    |\n    ===?|!=|>[>=]?|<=>|<[<=]?|[%&`/\\|]|\\*\\*?|=?~|[-+]@?|\\[]=?\n  )\n)\n\\s*(\\()",
@@ -2064,6 +2064,7 @@
 		},
 		{
 			"begin": "(?<={|{\\s|[^A-Za-z0-9_]do|^do|[^A-Za-z0-9_]do\\s|^do\\s)(\\|)",
+			"name": "meta.block.parameters.ruby",
 			"captures": {
 				"1": {
 					"name": "punctuation.separator.variable.ruby"
@@ -2072,11 +2073,24 @@
 			"end": "(?<!\\|)(\\|)(?!\\|)",
 			"patterns": [
 				{
-					"include": "source.ruby"
-				},
-				{
-					"match": "[_a-zA-Z][_a-zA-Z0-9]*",
-					"name": "variable.other.block.ruby"
+					"begin": "(?![\\s,|(])",
+					"end": "(?=,|\\|\\s*)",
+					"patterns": [
+						{
+							"match": "\\G([&*]?)([a-zA-Z][\\w_]*)|(_[\\w_]*)",
+							"captures": {
+								"1": {
+									"name": "storage.type.variable.ruby"
+								},
+								"2": {
+									"name": "variable.other.block.ruby"
+								},
+								"3": {
+									"name": "variable.other.block.unused.ruby variable.other.constant.ruby"
+								}
+							}
+						}
+					]
 				},
 				{
 					"match": ",",
@@ -2201,7 +2215,7 @@
 			]
 		},
 		{
-			"comment": "This is kindof experimental. There really is no way to perfectly match all regular variables, but you can pretty well assume that any normal word in certain curcumstances that havnt already been scoped as something else are probably variables, and the advantages beat the potential errors",
+			"comment": "This is kindof experimental. There really is no way to perfectly match all regular variables, but you can pretty well assume that any normal word in certain curcumstances that haven't already been scoped as something else are probably variables, and the advantages beat the potential errors",
 			"match": "((?<=\\W)\\b|^)\\w+\\b(?=\\s*([\\]\\)\\}\\=\\+\\-\\*\\/\\^\\$\\,\\.]|<\\s|<<[\\s|\\.]))",
 			"name": "variable.other.ruby"
 		}


### PR DESCRIPTION
Current Master Branch shows this for Block Parameters lists:
![image](https://user-images.githubusercontent.com/25099261/62462955-9b6cd600-b73d-11e9-8928-37ee8ec4a428.png)
![image](https://user-images.githubusercontent.com/25099261/62462969-a1fb4d80-b73d-11e9-8b05-d2e2f09d3dfe.png)

Minor modifications to the grammar allow block parameters to be highlighted more consistently:
![image](https://user-images.githubusercontent.com/25099261/62463014-c6efc080-b73d-11e9-84c8-3fbfbd46e54e.png)
![image](https://user-images.githubusercontent.com/25099261/62463025-cbb47480-b73d-11e9-8bea-90983f00a06e.png)

Added two new scopes:
`variable.other.block.unused.ruby` (to denote arguments that will go unused by the block, I've also kept the `variable.other.constant.ruby` that was previously applied to these so the highlighting stays even in the interim; `meta.block.parameters.ruby` to flesh out the detail of the scope.

Much of the matching for this was borrowed and modified off of the preexisting `meta.function.method.with-arguments.ruby` > `variable.parameter.function.ruby` scopes.