### PR TITLE
Fix for detecting rubocop output delimiter

### DIFF
--- a/packages/language-server-ruby/src/formatters/RuboCop.ts
+++ b/packages/language-server-ruby/src/formatters/RuboCop.ts
@@ -3,7 +3,7 @@ import { TextEdit } from 'vscode-languageserver';
 import BaseFormatter from './BaseFormatter';
 
 export default class RuboCop extends BaseFormatter {
-	protected FORMATTED_OUTPUT_DELIMITER = '====================';
+	protected FORMATTED_OUTPUT_DELIMITER = '====================\n';
 
 	get cmd(): string {
 		const command = 'rubocop';


### PR DESCRIPTION
This would be a quick fix for #519. (I tested this quickly modifying the extensions js file)

Given more thought it might be better to get the **first** instance of `FORMATTED_OUTPUT_DELIMITER`and not the last one to detect the end of rubocop diagnostics?

*Description of change and why it was needed here*

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run