### PR TITLE
Add chefignore as a valid Ruby file

### DIFF
--- a/package.json
+++ b/package.json
@@ -418,6 +418,7 @@
 					"appraisals",
 					"berksfile",
 					"brewfile",
+					"chefignore",
 					"capfile",
 					"deliverfile",
 					"fastfile",


### PR DESCRIPTION
It's ruby even though there's no extension and it should get all the bells and whistles of this extension.