### PR TITLE
Adds rubocop config file param

### DIFF
--- a/docs/linting.md
+++ b/docs/linting.md
@@ -42,13 +42,14 @@ or
 ```json
 "ruby.lint": {
   "rubocop": {
-    "command": "rubocop",  // setting this will override automatic detection
+    "command": "rubocop",  // setting this will override automatic detection and only works if useLanguageServer is enabled
     "useBundler": true,
     "lint": true, // enable lint cops
     "only": ["array", "of", "cops", "to", "run"],
     "except": ["array", "of", "cops", "not", "to", "run"],
     "require": ["array", "of", "ruby", "files", "to", "require"],
-    "rails": true // requires rubocop-rails gem for RuboCop >= 0.72.0
+    "rails": true, // requires rubocop-rails gem for RuboCop >= 0.72.0
+    "configFile": "/path/to/.rubocop.yml"
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
 							"properties": {
 								"command": {
 									"type": "string",
-									"description": "RuboCop command. Setting this will cause RuboCop to be executed this way and other settings will be ignored!"
+									"description": "RuboCop command. Setting this will cause RuboCop to be executed this way and other settings will be ignored! (only works if useLanguageServer is enabled)"
 								},
 								"useBundler": {
 									"type": "boolean",
@@ -276,7 +276,11 @@
 									"type": "boolean",
 									"default": false,
 									"description": "Rails cops are specific to the Ruby on Rails framework. These cops require the rubocop-rails gem for RuboCop >= 0.72.0"
-								}
+                },
+                "configFile": {
+                  "type": "string",
+                  "description": "Rubocop config file override (will be passed via -c argument)"
+                }
 							}
 						},
 						"standard": {

--- a/package.json
+++ b/package.json
@@ -276,11 +276,11 @@
 									"type": "boolean",
 									"default": false,
 									"description": "Rails cops are specific to the Ruby on Rails framework. These cops require the rubocop-rails gem for RuboCop >= 0.72.0"
-                },
-                "configFile": {
-                  "type": "string",
-                  "description": "Rubocop config file override (will be passed via -c argument)"
-                }
+								},
+								"configFile": {
+									"type": "string",
+									"description": "Rubocop config file override (will be passed via -c argument)"
+								}
 							}
 						},
 						"standard": {

--- a/packages/language-server-ruby/src/SettingsCache.ts
+++ b/packages/language-server-ruby/src/SettingsCache.ts
@@ -16,6 +16,7 @@ export type RuboCopLintConfiguration = RubyCommandConfiguration & {
 	require?: string[];
 	rails?: boolean;
 	forceExclusion?: boolean;
+	configFile?: string;
 };
 
 export interface RubyConfiguration {

--- a/packages/language-server-ruby/src/linters/RuboCop.ts
+++ b/packages/language-server-ruby/src/linters/RuboCop.ts
@@ -64,6 +64,7 @@ export default class RuboCop extends BaseLinter {
 		if (this.lintConfig.only) args = args.concat('--only', this.lintConfig.only.join(','));
 		if (this.lintConfig.except) args = args.concat('--except', this.lintConfig.except.join(','));
 		if (this.lintConfig.require) args = args.concat('-r', this.lintConfig.require.join(','));
+		if (this.lintConfig.configFile) args = args.concat('-c', this.lintConfig.configFile);
 		return args;
 	}
 

--- a/packages/vscode-ruby/src/lint/lib/linters/RuboCop.js
+++ b/packages/vscode-ruby/src/lint/lib/linters/RuboCop.js
@@ -13,7 +13,8 @@ function RuboCop(opts) {
 	if (opts.only) this.args = this.args.concat("--only", opts.only.join(','));
 	if (opts.except) this.args = this.args.concat("--except", opts.except.join(','));
 	if (opts.rails) this.args.push('-R');
-	if (opts.require) this.args = this.args.concat("-r", opts.require.join(','));
+  if (opts.require) this.args = this.args.concat("-r", opts.require.join(','));
+  if (opts.configFile) this.args = this.args.concat("-c", opts.configFile);
 }
 
 RuboCop.prototype.processResult = function (data) {

--- a/packages/vscode-ruby/src/lint/lib/linters/RuboCop.js
+++ b/packages/vscode-ruby/src/lint/lib/linters/RuboCop.js
@@ -13,15 +13,15 @@ function RuboCop(opts) {
 	if (opts.only) this.args = this.args.concat("--only", opts.only.join(','));
 	if (opts.except) this.args = this.args.concat("--except", opts.except.join(','));
 	if (opts.rails) this.args.push('-R');
-  if (opts.require) this.args = this.args.concat("-r", opts.require.join(','));
-  if (opts.configFile) this.args = this.args.concat("-c", opts.configFile);
+	if (opts.require) this.args = this.args.concat("-r", opts.require.join(','));
+	if (opts.configFile) this.args = this.args.concat("-c", opts.configFile);
 }
 
 RuboCop.prototype.processResult = function (data) {
 	if (data == '') {
 		return [];
 	}
-	let offenses = JSON.parse(data);
+	const offenses = JSON.parse(data);
 	if (offenses.summary.offense_count == 0) {
 		return [];
 	}


### PR DESCRIPTION
I required to overwrite the config file for Rubocop ( via the `-c` cli argument ) and added a config option.

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run
- [x] tested extension (only was able to test without languageServer because it keeps crashing on my ubuntu (same error message as in #533)