### PR TITLE
Improve method match

### DIFF
--- a/syntaxes/ruby.cson.json
+++ b/syntaxes/ruby.cson.json
@@ -2249,7 +2249,7 @@
 					"include": "#known_function_names"
 				},
 				{
-					"match": "([a-zA-Z0-9_!?]+)(?=\\()",
+					"match": "([a-zA-Z0-9_!?]+)((?=\\()|([!?]))",
 					"name": "entity.name.function.ruby"
 				},
 				{


### PR DESCRIPTION
Resolves https://github.com/rubyide/vscode-ruby/issues/540

the purely regex equivalent has been tested here https://regexr.com/4m699

The only difference is that two backslashes are required in json