### PR TITLE
Bugfix: Filter out linters that are disabled in the configuration.

### DIFF
--- a/packages/language-server-ruby/src/Linter.ts
+++ b/packages/language-server-ruby/src/Linter.ts
@@ -52,7 +52,9 @@ function lint(document: TextDocument): Observable<LintResult> {
 			);
 		}),
 		mergeMap(({ config, env }) => {
-			const linters = Object.keys(config.lint).map(l => getLinter(l, document, env, config).lint());
+			const linters = Object.keys(config.lint)
+				.filter(l => config.lint[l] !== false)
+				.map(l => getLinter(l, document, env, config).lint());
 			return forkJoin(linters).pipe(
 				map(diagnostics => {
 					return {


### PR DESCRIPTION
Fixes #531.

The getLinter() function just passes on the linter config (if it's an object), or continues with an empty object if it's any other values. This leads to unexpected behavior when setting a specific linter to `false` in the config. I.e. the linter is not disabled, as one would expect, but an empty linter configuration is used.

This PR fixes the issue by explicitly filtering linter configs that are `false` before passing them on to getLinter(). 

- [X] The build passes
- [X] TSLint is mostly happy
- [X] Prettier has been run