### PR TITLE
Add block snippets

### DIFF
--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -185,5 +185,28 @@
 			"\tend",
 			"end"
 		]
+	},
+	"Insert do … end block": {
+		"prefix": "do",
+		"body": [
+			"do",
+			"\t$0",
+			"end"
+		]
+	},
+	"Insert do |variable| … end block": {
+		"prefix": "dop",
+		"body": [
+			"do |${1:variable}|",
+			"\t$0",
+			"end"
+		]
+	},
+	"Insert curly braces block": {
+		"prefix": [
+			"{p",
+			"{P"
+		],
+		"body": "{ ${1:|${2:variable}| }$0 "
 	}
 }


### PR DESCRIPTION
This adds snippets for do..end blocks, do..end blocks with variables and
blocks with curly braces. Those snippets are super handy and IMHO essential. They are derived from the [atom ruby project](https://github.com/atom/language-ruby) and can be found here: https://github.com/atom/language-ruby/blob/master/snippets/language-ruby.cson#L153

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run