### PR TITLE
Add a reference to debug configuration doc

### DIFF
--- a/packages/vscode-ruby-client/README.md
+++ b/packages/vscode-ruby-client/README.md
@@ -49,6 +49,10 @@ Reviewing the [linting](https://github.com/rubyide/vscode-ruby/blob/master/docs/
 
 For full details on configuration options, please take a look at the `Ruby` section in the VS Code settings UI. Each option is associated with a name and description.
 
+### Debug Configuration
+
+See [docs/debugger.md](https://github.com/rubyide/vscode-ruby/blob/master/docs/debugger.md).
+
 ### Legacy Configuration
 
 [docs/legacy.md](https://github.com/rubyide/vscode-ruby/blob/master/docs/legacy.md) contains the documentation around the legacy functionality


### PR DESCRIPTION
Add a reference to debug configuration documentation in the README of vscode-ruby-client package; it is used in "Overview" section of the VS Code extension page and I think a reference there are necessary to inform users.