### PR TITLE
Add Stdin-filename arg to Reek linter

### DIFF
--- a/packages/language-server-ruby/src/linters/Reek.ts
+++ b/packages/language-server-ruby/src/linters/Reek.ts
@@ -1,3 +1,4 @@
+import { URI } from 'vscode-uri';
 import BaseLinter from './BaseLinter';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 
@@ -24,7 +25,8 @@ export default class Reek extends BaseLinter {
 	}
 
 	get args(): string[] {
-		return ['-f', 'json'];
+		const documentPath = URI.parse(this.document.uri);
+		return ['-f', 'json', '--stdin-filename', documentPath.fsPath];
 	}
 
 	protected processResults(data): Diagnostic[] {


### PR DESCRIPTION
Passes an `--stdin-filename` argument to Reek when linting files.

This gives Reek context about the piped contents and supports using the [`directories` configuration](https://github.com/troessner/reek#working-with-rails). 

Caveat:
Because this change sends the absolute path to the file, the configuration in directories must be prefixed with `**` for it to work. e.g.
```yml
directories:
  '**/app/controllers':
    IrresponsibleModule:
      enabled: false
```