### PR TITLE
Auto formatter through language server respect pathToBundler setting

### DIFF
--- a/packages/language-server-ruby/src/Formatter.ts
+++ b/packages/language-server-ruby/src/Formatter.ts
@@ -40,6 +40,7 @@ function getFormatter(
 			config: {
 				command: config.format,
 				useBundler: config.useBundler,
+				pathToBundler: config.pathToBundler
 			},
 		};
 

--- a/packages/language-server-ruby/src/SettingsCache.ts
+++ b/packages/language-server-ruby/src/SettingsCache.ts
@@ -5,6 +5,7 @@ import { loadEnv, RubyEnvironment } from 'vscode-ruby-common';
 export interface RubyCommandConfiguration {
 	command?: string;
 	useBundler?: boolean;
+	pathToBundler: string;
 }
 
 export interface RuboCopLintConfiguration extends RubyCommandConfiguration {
@@ -21,7 +22,6 @@ export interface RubyConfiguration extends RubyCommandConfiguration {
 	interpreter?: {
 		commandPath?: string;
 	};
-	pathToBundler: string;
 	lint: {
 		fasterer?: boolean | RubyConfiguration;
 		reek?: boolean | RubyConfiguration;

--- a/packages/language-server-ruby/src/formatters/BaseFormatter.ts
+++ b/packages/language-server-ruby/src/formatters/BaseFormatter.ts
@@ -61,7 +61,7 @@ export default abstract class BaseFormatter implements IFormatter {
 
 		if (this.useBundler) {
 			args.unshift('exec', cmd);
-			cmd = 'bundle';
+			cmd = this.config.config.pathToBundler || 'bundle';
 		}
 
 		const formatStr = `${cmd} ${args.join(' ')}`;


### PR DESCRIPTION
Expecting the formatter of the language server to respect the setting.

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run