### PR TITLE
Add Unix domain socket support to the debugger.

### DIFF
--- a/packages/vscode-ruby-client/package.json
+++ b/packages/vscode-ruby-client/package.json
@@ -666,6 +666,10 @@
 								"description": "Port for remote debugging.",
 								"default": "1234"
 							},
+							"localSocketPath": {
+								"type": "string",
+								"description": "Path to UNIX domain socket for remote debugging."
+							},
 							"remoteWorkspaceRoot": {
 								"type": "string",
 								"description": "Remote workspace root, this parameter is required for remote debugging.",

--- a/packages/vscode-ruby-debugger/src/interface.ts
+++ b/packages/vscode-ruby-debugger/src/interface.ts
@@ -1,9 +1,9 @@
-import {DebugProtocol} from 'vscode-debugprotocol';
+import { DebugProtocol } from 'vscode-debugprotocol';
 
 /**
  * This interface should always match the schema found in the vscode-ruby extension manifest.
  */
-export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments{
+export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
     /** An absolute path to the program to debug. */
     program: string;
     /** Optional arguments passed to the program being debugged. */
@@ -16,16 +16,18 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
     cwd?: string;
 }
 
-export interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments{
-	/** Executable working directory. */
+export interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
+    /** Executable working directory. */
     cwd?: string;
     /** Optional host address for remote debugging. */
     remoteHost?: string;
     /** Optional port for remote debugging. */
     remotePort?: string;
+    /** Path to UNIX domain socket for remote debugging. */
+    localSocketPath?: string;
     /** Optional remote workspace root, this parameter is required for remote debugging */
     remoteWorkspaceRoot?: string;
-	/** Show debugger process output. If not specified, there will only be executable output */
+    /** Show debugger process output. If not specified, there will only be executable output */
     showDebuggerOutput?: boolean;
 }
 

--- a/packages/vscode-ruby-debugger/src/ruby.ts
+++ b/packages/vscode-ruby-debugger/src/ruby.ts
@@ -1,27 +1,28 @@
 'use strict';
 
-import {basename, dirname} from 'path';
+import { basename, dirname } from 'path';
+import * as fs from 'fs';
 import * as net from 'net';
 import * as childProcess from 'child_process';
-import {EventEmitter} from 'events';
-import {DOMParser} from 'xmldom';
-import {LaunchRequestArguments, AttachRequestArguments, IRubyEvaluationResult, IDebugVariable, ICommand} from './interface';
-import {SocketClientState, Mode} from './common';
-import {includes} from './helper';
+import { EventEmitter } from 'events';
+import { DOMParser } from 'xmldom';
+import { LaunchRequestArguments, AttachRequestArguments, IRubyEvaluationResult, IDebugVariable, ICommand } from './interface';
+import { SocketClientState, Mode } from './common';
+import { includes } from './helper';
 
 var domErrorLocator: any = {};
 
-const ELEMENT_NODE:number = 1; // Node.ELEMENT_NODE
+const ELEMENT_NODE: number = 1; // Node.ELEMENT_NODE
 
 type ExecutableCommandConfiguration = {
-    pathToRuby : string;
-    useBundler : boolean;
-    pathToBundler : string;
-    rdebugIdePath : string;
+    pathToRuby: string;
+    useBundler: boolean;
+    pathToBundler: string;
+    rdebugIdePath: string;
 };
 
 export class RubyProcess extends EventEmitter {
-    private debugSocketClient : net.Socket = null;
+    private debugSocketClient: net.Socket = null;
     private buffer: string;
     private socketConnected: boolean;
     private parser: DOMParser;
@@ -31,7 +32,7 @@ export class RubyProcess extends EventEmitter {
     private _state: SocketClientState;
 
     private domErrors: any;
-    private domErrorHandler(type: string, error: string){
+    private domErrorHandler(type: string, error: string) {
         this.domErrors.push({
             lineNumber: domErrorLocator.lineNumber,
             columnNumber: domErrorLocator.columnNumber,
@@ -49,7 +50,7 @@ export class RubyProcess extends EventEmitter {
     }
 
     public executableCommandConfiguration(args) {
-        let rdebugIdeDefault : string;
+        let rdebugIdeDefault: string;
         if (process.platform === 'win32') {
             rdebugIdeDefault = 'rdebug-ide.bat';
         }
@@ -57,11 +58,11 @@ export class RubyProcess extends EventEmitter {
             rdebugIdeDefault = 'rdebug-ide';
         }
 
-        let result : ExecutableCommandConfiguration = {
+        let result: ExecutableCommandConfiguration = {
             pathToRuby: 'ruby',
             useBundler: false,
-            pathToBundler : 'bundle',
-            rdebugIdePath : rdebugIdeDefault
+            pathToBundler: 'bundle',
+            rdebugIdePath: rdebugIdeDefault
         }
 
         if (args.pathToRuby) {
@@ -89,7 +90,7 @@ export class RubyProcess extends EventEmitter {
 
         this.buffer = '';
         this.parser = new DOMParser({
-            errorHandler: (type,msg)=>this.domErrorHandler(type,msg),
+            errorHandler: (type, msg) => this.domErrorHandler(type, msg),
             locator: domErrorLocator
         });
 
@@ -99,7 +100,7 @@ export class RubyProcess extends EventEmitter {
             this.state = SocketClientState.connected;
             //first thing we have to send is the start - if stopOnEntry is
             //selected, rdebug-ide stops on the first executable line
-            this.pendingCommands.forEach( cmd => {
+            this.pendingCommands.forEach(cmd => {
                 this.pendingResponses.push(cmd);
                 this.debugSocketClient.write(cmd.command + '\n');
             });
@@ -113,16 +114,16 @@ export class RubyProcess extends EventEmitter {
             this.emit('debuggerComplete');
         });
 
-        this.debugSocketClient.on('close', d=> {
+        this.debugSocketClient.on('close', d => {
             this.state = SocketClientState.closed;
         });
 
-        this.debugSocketClient.on('error', d=> {
+        this.debugSocketClient.on('error', d => {
             var msg = 'Client: ' + d;
             this.emit('nonTerminalError', msg);
         });
 
-        this.debugSocketClient.on('timeout', d=> {
+        this.debugSocketClient.on('timeout', d => {
             var msg = 'Timeout: ' + d;
             this.emit('nonTerminalError', msg);
         });
@@ -132,53 +133,53 @@ export class RubyProcess extends EventEmitter {
             var threadId: any;
             //ensure the dom is stable (complete)
             this.domErrors = [];
-            var document: XMLDocument = this.parser.parseFromString(this.buffer,'application/xml');
-            if ( this.domErrors.length ){
+            var document: XMLDocument = this.parser.parseFromString(this.buffer, 'application/xml');
+            if (this.domErrors.length) {
                 //don't report stuff we can deal with happily
-                if ( !(
-                    includes(this.domErrors[0].error, 'unclosed xml attribute', 0)||
+                if (!(
+                    includes(this.domErrors[0].error, 'unclosed xml attribute', 0) ||
                     includes(this.domErrors[0].error, 'attribute space is required', 0) ||
                     includes(this.domErrors[0].error, "elements closed character '/' and '>' must be connected", 0)
-                    ))
-                    this.emit('debuggerOutput','Debugger failed to parse: ' + this.domErrors[0].error + "\nFor: " + this.buffer.slice(0,20));
-                if ( this.buffer.indexOf('<eval ') >= 0 &&
+                ))
+                    this.emit('debuggerOutput', 'Debugger failed to parse: ' + this.domErrors[0].error + "\nFor: " + this.buffer.slice(0, 20));
+                if (this.buffer.indexOf('<eval ') >= 0 &&
                     (includes(this.domErrors[0].error, 'attribute space is required', 0) ||
-                    includes(this.domErrors[0].error, "elements closed character '/' and '>' must be connected", 0))){
+                        includes(this.domErrors[0].error, "elements closed character '/' and '>' must be connected", 0))) {
                     //potentially an issue with the 'eval' tagName
                     let start = this.buffer.indexOf('<eval ');
-                    let end = this.buffer.indexOf('" />',start);
-                    if ( end < 0 ) return; //perhaps not all in yet
-                    start = this.buffer.indexOf(' value="',start);
-                    if ( start < 0 ) return; //not the right structure
+                    let end = this.buffer.indexOf('" />', start);
+                    if (end < 0) return; //perhaps not all in yet
+                    start = this.buffer.indexOf(' value="', start);
+                    if (start < 0) return; //not the right structure
                     start += 8;
-                    let inner = this.buffer.slice(start,end).replace(/\"/g,'&quot;');
-                    this.buffer = this.buffer.slice(0,start) + inner + this.buffer.slice(end);
+                    let inner = this.buffer.slice(start, end).replace(/\"/g, '&quot;');
+                    this.buffer = this.buffer.slice(0, start) + inner + this.buffer.slice(end);
                     this.domErrors = [];
-                    document = this.parser.parseFromString(this.buffer,'application/xml');
+                    document = this.parser.parseFromString(this.buffer, 'application/xml');
                 } else return; //one of the xml elements is incomplete
             }
             //if it's still bad: - we need to do something else with this
-            if ( this.domErrors.length ) return;
+            if (this.domErrors.length) return;
 
-            for (let idx = 0; idx < document.childNodes.length; idx++){
+            for (let idx = 0; idx < document.childNodes.length; idx++) {
                 let node: any = document.childNodes[idx];
                 let attributes: any = {};
-                if (node.attributes && node.attributes.length){
-                    for (let attrIdx = 0; attrIdx < node.attributes.length; attrIdx++){
+                if (node.attributes && node.attributes.length) {
+                    for (let attrIdx = 0; attrIdx < node.attributes.length; attrIdx++) {
                         attributes[node.attributes[attrIdx].name] = node.attributes[attrIdx].value;
                     }
-                    if ( attributes.threadId ) attributes.threadId = +attributes.threadId;
+                    if (attributes.threadId) attributes.threadId = +attributes.threadId;
                 }
                 //the structure here only has one or the other
-                if (node.childNodes && node.childNodes.length){
+                if (node.childNodes && node.childNodes.length) {
                     let finalAttributes = [];
                     //all of the child nodes are the same type in our responses
-                    for (let nodeIdx = 0; nodeIdx < node.childNodes.length; nodeIdx++){
+                    for (let nodeIdx = 0; nodeIdx < node.childNodes.length; nodeIdx++) {
                         let childNode = node.childNodes[nodeIdx];
-                        if ( childNode.nodeType !== ELEMENT_NODE ) continue;
+                        if (childNode.nodeType !== ELEMENT_NODE) continue;
                         attributes = {}
-                        if ( childNode.attributes && childNode.attributes.length ){
-                            for (let attrIdx = 0; attrIdx < childNode.attributes.length; attrIdx++){
+                        if (childNode.attributes && childNode.attributes.length) {
+                            for (let attrIdx = 0; attrIdx < childNode.attributes.length; attrIdx++) {
                                 attributes[childNode.attributes[attrIdx].name] = childNode.attributes[attrIdx].value;
                             }
                         }
@@ -186,8 +187,8 @@ export class RubyProcess extends EventEmitter {
                     }
                     attributes = finalAttributes;
                 }
-                if ( ['breakpoint','suspended','exception'].indexOf(node.tagName) >= 0){
-                    this.emit(node.tagName, attributes );
+                if (['breakpoint', 'suspended', 'exception'].indexOf(node.tagName) >= 0) {
+                    this.emit(node.tagName, attributes);
                 }
                 //this just assumes we don't get anything in between
                 else this.FinishCmd(attributes);
@@ -198,7 +199,7 @@ export class RubyProcess extends EventEmitter {
         let executableCommandConfiguration = this.executableCommandConfiguration(args);
 
         if (mode == Mode.launch) {
-            var runtimeArgs : string[];
+            var runtimeArgs: string[];
             var runtimeExecutable: string;
 
             if (args.noDebug) {
@@ -209,16 +210,16 @@ export class RubyProcess extends EventEmitter {
                 runtimeExecutable = executableCommandConfiguration.rdebugIdePath;
                 runtimeArgs = ['--evaluation-timeout', '10']
 
-                if (args.showDebuggerOutput){
+                if (args.showDebuggerOutput) {
                     runtimeArgs.push('-x');
                 }
 
-                if (args.debuggerPort && args.debuggerPort !== '1234'){
+                if (args.debuggerPort && args.debuggerPort !== '1234') {
                     runtimeArgs.push('-p');
                     runtimeArgs.push(args.debuggerPort);
                 }
 
-                if (args.stopOnEntry){
+                if (args.stopOnEntry) {
                     runtimeArgs.push('--stop');
                 }
             }
@@ -227,21 +228,21 @@ export class RubyProcess extends EventEmitter {
 
             var processEnv = {};
             //use process environment
-            for( var env in process.env) {
+            for (var env in process.env) {
                 processEnv[env] = process.env[env];
             }
             //merge supplied environment
-            for( var env in args.env) {
+            for (var env in args.env) {
                 processEnv[env] = args.env[env];
             }
 
-            if (executableCommandConfiguration.useBundler){
+            if (executableCommandConfiguration.useBundler) {
                 runtimeArgs.unshift(runtimeExecutable);
                 runtimeArgs.unshift('exec');
                 runtimeExecutable = executableCommandConfiguration.pathToBundler;
             }
 
-            if (args.includes){
+            if (args.includes) {
                 args.includes.forEach((path) => {
                     runtimeArgs.push('-I')
                     runtimeArgs.push(path)
@@ -249,7 +250,7 @@ export class RubyProcess extends EventEmitter {
             }
 
             // '--' forces process arguments (args.args) not to be swollowed by rdebug-ide
-            this.debugprocess = childProcess.spawn(runtimeExecutable, [...runtimeArgs, '--', args.program, ...args.args || []], {cwd: processCwd, env: processEnv});
+            this.debugprocess = childProcess.spawn(runtimeExecutable, [...runtimeArgs, '--', args.program, ...args.args || []], { cwd: processCwd, env: processEnv });
 
             // redirect output to debug console
             this.debugprocess.stdout.on('data', (data: Buffer) => {
@@ -277,7 +278,20 @@ export class RubyProcess extends EventEmitter {
             });
         }
         else {
-            this.debugSocketClient.connect(args.remotePort, args.remoteHost);
+            if (args.localSocketPath) {
+                fs.access(args.localSocketPath, err => {
+                    if (err) {
+                        this.emit('debuggerOutput', 'Error: ' + err.toString());
+                        this.emit('debuggerComplete');
+                    } else {
+                        this.emit('debuggerOutput', 'Connecting to ' + args.localSocketPath);
+                        this.debugSocketClient.connect(args.localSocketPath);
+                    }
+                });
+            }
+            else {
+                this.debugSocketClient.connect(args.remotePort, args.remoteHost);
+            }
         }
     }
 
@@ -296,7 +310,7 @@ export class RubyProcess extends EventEmitter {
     }
 
     public Enqueue(cmd: string): Promise<any> {
-        var pro =  new Promise<any>((resolve, reject) => {
+        var pro = new Promise<any>((resolve, reject) => {
             var newCommand = {
                 command: cmd,
                 resolve: resolve,


### PR DESCRIPTION
Add Unix domain socket support to the debugger.

Makes it possible to attach to running Ruby processes via a Unix domain socket.

At Stripe, we're using a forked version of this extension in order to securely attach to Ruby services running on development boxes via Unix domain sockets. We'd like to upstream the change. :) 

Let me know if you need any more information or if this PR needs any additional changes.

- [X] The build passes - The debugger tests fail locally for me with or without the change.
- [ ] TSLint is mostly happy - 🤷‍♂ 
- [ ] Prettier has been run - No, because this package seems to have never been prettiered and I didn't want to dirty the diff. The existing changes are from VS Code's built-in formatter, which seems to have fixed some whitespace issues without radically transforming the code. If this is distracting, I can golf down the diff. :) 