### PR TITLE
Add BUNDLE_PATH to whitelisted env variables

### DIFF
--- a/packages/vscode-ruby-client/src/util/env.ts
+++ b/packages/vscode-ruby-client/src/util/env.ts
@@ -93,6 +93,7 @@ const RUBY_ENVIRONMENT_VARIABLES = [
 	'HOME',
 	'RUBOCOP_OPTS',
 	'LANG',
+	'BUNDLE_PATH',
 ];
 
 export interface IEnvironment {

--- a/packages/vscode-ruby-common/src/environment.ts
+++ b/packages/vscode-ruby-common/src/environment.ts
@@ -139,6 +139,7 @@ const RUBY_ENVIRONMENT_VARIABLES = [
 	'HOME',
 	'RUBOCOP_OPTS',
 	'LANG',
+	'BUNDLE_PATH',
 ];
 
 export interface IEnvironment {


### PR DESCRIPTION
It is an official Bundler env variable as demonstrated here:
https://bundler.io/v2.0/bundle_install.html
Resolves https://github.com/rubyide/vscode-ruby/issues/574

- I was not able to get the build to fully pass locally, even on master, despite following the development guide, because it says `UnhandledPromiseRejectionWarning: Error: no event 'initialized' received after 5000 ms`
- I was not able to get ESLint to run because it says `[Error - 10:55:25 AM] .eslintrc.json » ../.eslintrc.base.json: 	Configuration for rule "@typescript-eslint/array-type" is invalid: 	Value "array" should be object. `
- It appears that Prettier works fine