### PR TITLE
Respect pathToBundler setting when linting / formatting via language server

### DIFF
--- a/packages/language-server-ruby/src/Formatter.ts
+++ b/packages/language-server-ruby/src/Formatter.ts
@@ -42,6 +42,7 @@ function getFormatter(
 			config: {
 				command: config.format,
 				useBundler: config.useBundler,
+				pathToBundler: config.pathToBundler,
 			},
 		};
 

--- a/packages/language-server-ruby/src/Linter.ts
+++ b/packages/language-server-ruby/src/Linter.ts
@@ -44,7 +44,10 @@ function getLinter(
 	const linterConfig: LinterConfig = {
 		env,
 		executionRoot,
-		config: lintConfig,
+		config: {
+			pathToBundler: config.pathToBundler,
+			...lintConfig,
+		},
 	};
 	return new linter(document, linterConfig); // eslint-disable-line new-cap
 }

--- a/packages/language-server-ruby/src/SettingsCache.ts
+++ b/packages/language-server-ruby/src/SettingsCache.ts
@@ -6,6 +6,7 @@ import { LogLevelDesc } from 'loglevel';
 export interface RubyCommandConfiguration {
 	command?: string;
 	useBundler?: boolean;
+	pathToBundler?: string;
 }
 
 export interface RuboCopLintConfiguration extends RubyCommandConfiguration {

--- a/packages/language-server-ruby/src/formatters/BaseFormatter.ts
+++ b/packages/language-server-ruby/src/formatters/BaseFormatter.ts
@@ -62,7 +62,7 @@ export default abstract class BaseFormatter implements IFormatter {
 
 		if (this.useBundler) {
 			args.unshift('exec', cmd);
-			cmd = 'bundle';
+			cmd = this.config.config.pathToBundler || 'bundle';
 		}
 
 		const formatStr = `${cmd} ${args.join(' ')}`;

--- a/packages/language-server-ruby/src/linters/BaseLinter.ts
+++ b/packages/language-server-ruby/src/linters/BaseLinter.ts
@@ -43,7 +43,7 @@ export default abstract class BaseLinter implements ILinter {
 
 		if (!this.lintConfig.command && this.lintConfig.useBundler) {
 			args.unshift('exec', cmd);
-			cmd = 'bundle';
+			cmd = this.config.config.pathToBundler || 'bundle';
 		}
 
 		log.info(`Lint: executing ${cmd} ${args.join(' ')}...`);


### PR DESCRIPTION
resolves #581 

With this PR the `pathToBundler` setting gets used, when linting / formatting code via the language server.

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run