### PR TITLE
Update Variable Other to Recognize if variable includes ? or !

### DIFF
--- a/packages/vscode-ruby/syntaxes/ruby.cson.json
+++ b/packages/vscode-ruby/syntaxes/ruby.cson.json
@@ -2264,7 +2264,7 @@
 		},
 		{
 			"comment": "This is kindof experimental. There really is no way to perfectly match all regular variables, but you can pretty well assume that any normal word in certain curcumstances that haven't already been scoped as something else are probably variables, and the advantages beat the potential errors",
-			"match": "((?<=\\W)\\b|^)\\w+\\b(?=\\s*([\\]\\)\\}\\=\\+\\-\\*\\/\\^\\$\\,\\.\\&]|<\\s|<<[\\s|\\.])?)",
+			"match": "((?<=\\W)\\b|^)\\w+[?!]\\B|\\w+\\b(?=\\s*([\\]\\)\\}\\=\\+\\-\\*\\/\\^\\$\\,\\.\\&]|<\\s|<<[\\s|\\.])?)",
 			"name": "variable.other.ruby"
 		}
 	],


### PR DESCRIPTION
Inconsistent syntax highlighting causing word if followed by a `?` or `!` are not recognized together.

Ruby allows for [method names](https://docs.ruby-lang.org/en/master/syntax/methods_rdoc.html#label-Method+Names) to include `?` & `!`.

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run