### PR TITLE
Fix Block Comment

### DIFF
--- a/packages/vscode-ruby/language-configuration-erb.json
+++ b/packages/vscode-ruby/language-configuration-erb.json
@@ -1,6 +1,6 @@
 {
 	"comments": {
-		"blockComment": [ "<%#", "%>" ]
+		"blockComment": [ "<!--", "-->" ]
 	},
 	"brackets": [
 		["{", "}"],


### PR DESCRIPTION
Block Comments not properly commenting out blocks for `erb` grammar.
Setting block comments to traditional html solves issue.

**Before**: 
<img width="348" alt="before" src="https://user-images.githubusercontent.com/44587895/79371936-05af5a80-7f0a-11ea-8447-2ffe901151e5.png">
- Third example only works when manually typing `#` after `<%` .

**After**:
<img width="385" alt="after" src="https://user-images.githubusercontent.com/44587895/79371915-fb8d5c00-7f09-11ea-85ca-100fcb6cd8d4.png">
- Third example still respects manually typing `#` after `<%`  commenting out due to grammar regex.
- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run