### PR TITLE
Add Ternary Else Operator : to Keywords

### DIFF
--- a/packages/vscode-ruby/syntaxes/ruby.cson.json
+++ b/packages/vscode-ruby/syntaxes/ruby.cson.json
@@ -2158,6 +2158,10 @@
 			"name": "keyword.operator.comparison.ruby"
 		},
 		{
+			"match": "(?<=[\\040\\t]):(?=[\\040\\t])",
+			"name": "keyword.operator.ternary.ruby"
+		},
+		{
 			"match": "(?<!\\.)\\b(and|not|or)\\b(?![?!])",
 			"name": "keyword.operator.logical.ruby"
 		},


### PR DESCRIPTION
Add Ternary `:` Operator.

[Ternary if](https://docs.ruby-lang.org/en/2.7.0/syntax/control_expressions_rdoc.html#label-Ternary+if)

Following similar pattern for `?` comparison operator: `(?<=[ \\t])\\?`

**Before**:
<img width="226" alt="before" src="https://user-images.githubusercontent.com/44587895/79190563-786ce880-7dd9-11ea-8a0d-846221956730.png">
- `:` treated as `punctuation.separator.other.ruby`.
- Should be treated as `else`.

**After**:
<img width="199" alt="after" src="https://user-images.githubusercontent.com/44587895/79190598-90dd0300-7dd9-11ea-9030-936677662ed7.png">
- `:` treated as `keyword.operator.ternary.ruby`.

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run