### PR TITLE
Add Range Operator

### DIFF
--- a/packages/vscode-ruby/syntaxes/ruby.cson.json
+++ b/packages/vscode-ruby/syntaxes/ruby.cson.json
@@ -2162,6 +2162,10 @@
 			"name": "keyword.operator.logical.ruby"
 		},
 		{
+			"match": "(?<=[^\\.\\s])\\.{2,3}(?=[^\\.\\s])",
+			"name": "keyword.operator.range.ruby"
+		},
+		{
 			"match": "(?<=^|[ \\t!])!|&&|\\|\\||\\^",
 			"name": "keyword.operator.logical.ruby"
 		},


### PR DESCRIPTION
Range operators unidentified causing inconsistent inconsistent syntax highlighting.

**Docs**: [Ruby Range](https://ruby-doc.org/core-2.7.1/Range.html).

**Before**:
<img width="183" alt="before" src="https://user-images.githubusercontent.com/44587895/79189794-8a4d8c00-7dd7-11ea-8750-361fa4be2837.png">
- Dot preceding `Class` (`variable.other.constant.ruby`) unidentified (`source.ruby`)
- Other dots identified as `punctuation.separator.method.ruby`

**After**:
<img width="181" alt="after" src="https://user-images.githubusercontent.com/44587895/79189806-8faad680-7dd7-11ea-911f-d7305c536c87.png">
- Now Identify as `keyword.operator.range.ruby`.


- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run