### PR TITLE
Add default debug configuration for Minitest

### DIFF
--- a/packages/vscode-ruby-client/src/providers/configuration.ts
+++ b/packages/vscode-ruby-client/src/providers/configuration.ts
@@ -53,6 +53,17 @@ const rubyConfigurations: vscode.DebugConfiguration[] = [
 		args: ['server'],
 	},
 	{
+		name: 'Minitest - current line',
+		type: 'Ruby',
+		cwd: '${workspaceRoot}',
+		request: 'launch',
+		program: '${workspaceRoot}/bin/rails',
+		args: [
+			'test',
+			'${file}:${lineNumber}'
+		]
+	},
+	{
 		name: 'RSpec - all',
 		type: 'Ruby',
 		request: 'launch',


### PR DESCRIPTION
Adds a default configuration for debugging Minitest tests as per https://github.com/rubyide/vscode-ruby/issues/630