### PR TITLE
put standard config in ruby.lint keyspace

### DIFF
--- a/docs/linting.md
+++ b/docs/linting.md
@@ -71,12 +71,14 @@ or
 
 ```json
 {
-  "standard": {
-    "command": "standard",  // setting this will override automatic detection
-    "useBundler": true,
-    "only": ["array", "of", "cops", "to", "run"],
-    "except": ["array", "of", "cops", "not", "to", "run"],
-    "require": ["array", "of", "ruby", "files", "to, "require"]
+  "ruby.lint": {
+    "standard": {
+      "command": "standard",  // setting this will override automatic detection
+      "useBundler": true,
+      "only": ["array", "of", "cops", "to", "run"],
+      "except": ["array", "of", "cops", "not", "to", "run"],
+      "require": ["array", "of", "ruby", "files", "to, "require"]
+    }
   }
 }
 ```

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -70,15 +70,13 @@ See the [standard docs](https://github.com/testdouble/standard#what-you-might-do
 or
 
 ```json
-{
-  "ruby.lint": {
-    "standard": {
-      "command": "standard",  // setting this will override automatic detection
-      "useBundler": true,
-      "only": ["array", "of", "cops", "to", "run"],
-      "except": ["array", "of", "cops", "not", "to", "run"],
-      "require": ["array", "of", "ruby", "files", "to, "require"]
-    }
+"ruby.lint": {
+  "standard": {
+    "command": "standard",  // setting this will override automatic detection
+    "useBundler": true,
+    "only": ["array", "of", "cops", "to", "run"],
+    "except": ["array", "of", "cops", "not", "to", "run"],
+    "require": ["array", "of", "ruby", "files", "to, "require"]
   }
 }
 ```


### PR DESCRIPTION
The standard config object example was not nested in `"ruby.lint"`.

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run