### PR TITLE
Wrap documentPath.fsPath in single quotes to support file paths with spaces

### DIFF
--- a/packages/language-server-ruby/src/formatters/RuboCop.ts
+++ b/packages/language-server-ruby/src/formatters/RuboCop.ts
@@ -13,7 +13,7 @@ export default class RuboCop extends BaseFormatter {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		const args = ['-s', documentPath.fsPath, '-a'];
+		const args = ['-s', `'${documentPath.fsPath}'`, '-a'];
 		return args;
 	}
 

--- a/packages/language-server-ruby/src/formatters/Rufo.ts
+++ b/packages/language-server-ruby/src/formatters/Rufo.ts
@@ -9,6 +9,6 @@ export default class Rubocop extends BaseFormatter {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		return [`--filename=${documentPath.fsPath}`, '-x'];
+		return [`--filename='${documentPath.fsPath}'`, '-x'];
 	}
 }

--- a/packages/language-server-ruby/src/formatters/Standard.ts
+++ b/packages/language-server-ruby/src/formatters/Standard.ts
@@ -9,7 +9,7 @@ export default class Standard extends RuboCop {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		let args = ['-s', documentPath.fsPath, '--fix'];
+		let args = ['-s', `'${documentPath.fsPath}'`, '--fix'];
 		return args;
 	}
 }

--- a/packages/language-server-ruby/src/linters/Reek.ts
+++ b/packages/language-server-ruby/src/linters/Reek.ts
@@ -27,7 +27,7 @@ export default class Reek extends BaseLinter {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		return ['-f', 'json', '--stdin-filename', documentPath.fsPath];
+		return ['-f', 'json', '--stdin-filename', `'${documentPath.fsPath}'`];
 	}
 
 	protected processResults(data): Diagnostic[] {

--- a/packages/language-server-ruby/src/linters/RuboCop.ts
+++ b/packages/language-server-ruby/src/linters/RuboCop.ts
@@ -58,7 +58,7 @@ export default class RuboCop extends BaseLinter {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		let args = ['-s', documentPath.fsPath, '-f', 'json'];
+		let args = ['-s', `'${documentPath.fsPath}'`, '-f', 'json'];
 		if (this.lintConfig.rails) args.push('-R');
 		if (this.lintConfig.forceExclusion) args.push('--force-exclusion');
 		if (this.lintConfig.lint) args.push('-l');


### PR DESCRIPTION
Closes #641 

*Description of change and why it was needed here*

Single quotes around the `documentPath.fsPath` is necessary to support file paths that include spaces.

- [X] The build passes
- [X] TSLint is mostly happy
- [X] Prettier has been run