### PR TITLE
Check for : @ and $ before 'do'

### DIFF
--- a/packages/vscode-ruby/syntaxes/ruby.cson.json
+++ b/packages/vscode-ruby/syntaxes/ruby.cson.json
@@ -2106,7 +2106,7 @@
 			]
 		},
 		{
-			"begin": "(?<={|{\\s|[^A-Za-z0-9_]do|^do|[^A-Za-z0-9_]do\\s|^do\\s)(\\|)",
+			"begin": "(?<={|{\\s|[^A-Za-z0-9_:@$]do|^do|[^A-Za-z0-9_:@$]do\\s|^do\\s)(\\|)",
 			"name": "meta.block.parameters.ruby",
 			"captures": {
 				"1": {

--- a/packages/vscode-ruby/test/syntax.rb
+++ b/packages/vscode-ruby/test/syntax.rb
@@ -71,4 +71,24 @@ class ExampleClass < AnotherClass
     !!obj
 #   ^^ keyword.operator.logical.ruby
   end
+
+  def self.do
+# ^^^ keyword.control.def.ruby
+#     ^^^^^^^ meta.function.method.without-arguments.ruby entity.name.function.ruby
+    @do ||= {}
+#   ^ variable.other.readwrite.instance.ruby punctuation.definition.variable.ruby
+#    ^^ variable.other.readwrite.instance.ruby
+#       ^^^ keyword.operator.assignment.augmented.ruby
+#           ^ punctuation.section.scope.begin.ruby
+#            ^ punctuation.section.scope.end.ruby
+  end
+# ^^^ keyword.control.ruby
 end
+
+
+  weird_method :do || true
+# ^^^^^^^^^^^^ variable.other.ruby
+#              ^ constant.language.symbol.ruby punctuation.definition.constant.ruby
+#               ^^ constant.language.symbol.ruby
+#                  ^^ keyword.operator.logical.ruby
+#                     ^^^^ constant.language.boolean.ruby


### PR DESCRIPTION
This is a fix for  #658 
First I just wanted to check that there is a start of line or space char before `do` keyword, but there is some weird cases where you can put `do` right after the method name without space:

```ruby
def +
  yield "test"
end

self.+do |e|
  e.upcase
end
```
I am pretty sure this will work for any of these methods: `+`, `-`, `*`, `/`, `^`, `%`, `&`, `|`
Blocks are rarely used with them and blocks without space between method name and `do` I think almost never.
So I am not sure what is better.