### PR TITLE
Fix highlighting of method parameters. Add support for multiline parameters. 

### DIFF
--- a/packages/vscode-ruby/syntaxes/ruby.cson.json
+++ b/packages/vscode-ruby/syntaxes/ruby.cson.json
@@ -268,30 +268,16 @@
 			"name": "meta.function.method.with-arguments.ruby",
 			"patterns": [
 				{
-					"begin": "(?![\\s,)])",
-					"end": "(?=,|\\)\\s*$)",
+					"begin": "(?=[&*_a-zA-Z])",
+					"end": "(?=[,)])",
 					"patterns": [
 						{
-							"captures": {
-								"1": {
-									"name": "storage.type.variable.ruby"
-								},
-								"2": {
-									"name": "constant.language.symbol.hashkey.parameter.function.ruby"
-								},
-								"3": {
-									"name": "punctuation.definition.constant.hashkey.ruby"
-								},
-								"4": {
-									"name": "variable.parameter.function.ruby"
-								}
-							},
-							"match": "\\G([&*]?)(?:([_a-zA-Z]\\w*(:))|([_a-zA-Z]\\w*))"
-						},
-						{
-							"include": "$self"
+							"include": "#method_parameters"
 						}
 					]
+				},
+				{
+					"include": "#method_parameters"
 				}
 			]
 		},
@@ -306,34 +292,20 @@
 				}
 			},
 			"comment": "same as the previous rule, but without parentheses around the arguments",
-			"end": "$",
+			"end": "(?=;)|(?<=[\\w\\])}`'\"!?])(?=\\s*#|\\s*$)",
 			"name": "meta.function.method.with-arguments.ruby",
 			"patterns": [
 				{
-					"begin": "(?![\\s,])",
-					"end": "(?=,|$)",
+					"begin": "(?=[&*_a-zA-Z])",
+					"end": "(?=,|;|\\s*#|\\s*$)",
 					"patterns": [
 						{
-							"captures": {
-								"1": {
-									"name": "storage.type.variable.ruby"
-								},
-								"2": {
-									"name": "constant.language.symbol.hashkey.parameter.function.ruby"
-								},
-								"3": {
-									"name": "punctuation.definition.constant.hashkey.ruby"
-								},
-								"4": {
-									"name": "variable.parameter.function.ruby"
-								}
-							},
-							"match": "\\G([&*]?)(?:([_a-zA-Z]\\w*(:))|([_a-zA-Z]\\w*))"
-						},
-						{
-							"include": "$self"
+							"include": "#method_parameters"
 						}
 					]
+				},
+				{
+					"include": "#method_parameters"
 				}
 			]
 		},
@@ -2269,6 +2241,128 @@
 		}
 	],
 	"repository": {
+		"method_parameters": {
+			"patterns": [
+				{
+					"include": "#parens"
+				},
+				{
+					"include": "#braces"
+				},
+				{
+					"include": "#brackets"
+				},
+				{
+					"include": "#params"
+				},
+				{
+					"include": "$self"
+				}
+			],
+			"repository": {
+				"params": {
+					"captures": {
+						"1": {
+							"name": "storage.type.variable.ruby"
+						},
+						"2": {
+							"name": "constant.other.symbol.hashkey.parameter.function.ruby"
+						},
+						"3": {
+							"name": "punctuation.definition.constant.ruby"
+						},
+						"4": {
+							"name": "variable.parameter.function.ruby"
+						}
+					},
+					"match": "\\G(&|\\*\\*?)?(?:([_a-zA-Z]\\w*(:))|([_a-zA-Z]\\w*))"
+				},
+				"braces": {
+					"begin": "\\{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.scope.begin.ruby"
+						}
+					},
+					"end": "\\}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.scope.end.ruby"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#parens"
+						},
+						{
+							"include": "#braces"
+						},
+						{
+							"include": "#brackets"
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				"brackets": {
+					"begin": "\\[",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.array.begin.ruby"
+						}
+					},
+					"end": "\\]",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.array.end.ruby"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#parens"
+						},
+						{
+							"include": "#braces"
+						},
+						{
+							"include": "#brackets"
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				"parens": {
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.function.begin.ruby"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.function.end.ruby"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#parens"
+						},
+						{
+							"include": "#braces"
+						},
+						{
+							"include": "#brackets"
+						},
+						{
+							"include": "$self"
+						}
+					]
+				}
+			}
+		},
 		"escaped_char": {
 			"match": "\\\\(?:[0-7]{1,3}|x[\\da-fA-F]{1,2}|.)",
 			"name": "constant.character.escape.ruby"

--- a/packages/vscode-ruby/test/methods.rb
+++ b/packages/vscode-ruby/test/methods.rb
@@ -1,0 +1,497 @@
+# SYNTAX TEST "source.ruby"
+
+  def method; hello, world = [1,2] end # test comment
+# ^^^ meta.function.method.without-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^ meta.function.method.without-arguments.ruby entity.name.function.ruby
+#           ^ punctuation.separator.statement.ruby
+#             ^^^^^ variable.other.ruby
+#                  ^ punctuation.separator.object.ruby
+#                    ^^^^^ variable.other.ruby
+#                          ^ keyword.operator.assignment.ruby
+#                            ^ punctuation.section.array.begin.ruby
+#                             ^ constant.numeric.ruby
+#                              ^ punctuation.separator.object.ruby
+#                               ^ constant.numeric.ruby
+#                                ^ punctuation.section.array.end.ruby
+#                                  ^^^ keyword.control.ruby
+#                                      ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                       ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+
+
+  def method # test comment
+# ^^^ meta.function.method.without-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^ meta.function.method.without-arguments.ruby entity.name.function.ruby
+#            ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#             ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+    hello, world = [1,2]
+#   ^^^^^ variable.other.ruby
+#        ^ punctuation.separator.object.ruby
+#          ^^^^^ variable.other.ruby
+#                ^ keyword.operator.assignment.ruby
+#                  ^ punctuation.section.array.begin.ruby
+#                   ^ constant.numeric.ruby
+#                    ^ punctuation.separator.object.ruby
+#                     ^ constant.numeric.ruby
+#                      ^ punctuation.section.array.end.ruby
+  end
+# ^^^ keyword.control.ruby 
+
+
+  def method_with_parentheses(*a, **b, &c) hello, world = [1,2] end # test comment
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                            ^ meta.function.method.with-arguments.ruby punctuation.definition.parameters.ruby
+#                             ^ meta.function.method.with-arguments.ruby storage.type.variable.ruby
+#                              ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                               ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                 ^^ meta.function.method.with-arguments.ruby storage.type.variable.ruby
+#                                   ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                    ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                      ^ meta.function.method.with-arguments.ruby storage.type.variable.ruby
+#                                       ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                        ^ meta.function.method.with-arguments.ruby punctuation.definition.parameters.ruby
+#                                          ^^^^^ variable.other.ruby
+#                                               ^ punctuation.separator.object.ruby
+#                                                 ^^^^^ variable.other.ruby
+#                                                       ^ keyword.operator.assignment.ruby
+#                                                         ^ punctuation.section.array.begin.ruby
+#                                                          ^ constant.numeric.ruby
+#                                                           ^ punctuation.separator.object.ruby
+#                                                            ^ constant.numeric.ruby
+#                                                             ^ punctuation.section.array.end.ruby
+#                                                               ^^^ keyword.control.ruby
+#                                                                   ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                                                    ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+
+
+  def method_with_parentheses(a, b, c = [foo,bar,baz]) hello, world = [1,2] end # test comment
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                            ^ meta.function.method.with-arguments.ruby punctuation.definition.parameters.ruby
+#                             ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                              ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                 ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                   ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                     ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                       ^ meta.function.method.with-arguments.ruby punctuation.section.array.begin.ruby
+#                                        ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                           ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                            ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                               ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                                   ^ meta.function.method.with-arguments.ruby punctuation.section.array.end.ruby
+#                                                    ^ meta.function.method.with-arguments.ruby punctuation.definition.parameters.ruby
+#                                                      ^^^^^ variable.other.ruby
+#                                                           ^ punctuation.separator.object.ruby
+#                                                             ^^^^^ variable.other.ruby
+#                                                                   ^ keyword.operator.assignment.ruby
+#                                                                     ^ punctuation.section.array.begin.ruby
+#                                                                      ^ constant.numeric.ruby
+#                                                                       ^ punctuation.separator.object.ruby
+#                                                                        ^ constant.numeric.ruby
+#                                                                         ^ punctuation.section.array.end.ruby
+#                                                                           ^^^ keyword.control.ruby
+#                                                                               ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                                                                ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+
+
+  def method_with_parentheses(a, b, c = [foo,bar,baz]) # test comment
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                            ^ meta.function.method.with-arguments.ruby punctuation.definition.parameters.ruby
+#                             ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                              ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                 ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                   ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                     ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                       ^ meta.function.method.with-arguments.ruby punctuation.section.array.begin.ruby
+#                                        ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                           ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                            ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                               ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                                   ^ meta.function.method.with-arguments.ruby punctuation.section.array.end.ruby
+#                                                    ^ meta.function.method.with-arguments.ruby punctuation.definition.parameters.ruby
+#                                                      ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                                       ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+    hello, world = [1,2]
+#   ^^^^^ variable.other.ruby
+#        ^ punctuation.separator.object.ruby
+#          ^^^^^ variable.other.ruby
+#                ^ keyword.operator.assignment.ruby
+#                  ^ punctuation.section.array.begin.ruby
+#                   ^ constant.numeric.ruby
+#                    ^ punctuation.separator.object.ruby
+#                     ^ constant.numeric.ruby
+#                      ^ punctuation.section.array.end.ruby
+  end
+# ^^^ keyword.control.ruby 
+
+
+  def method_with_parentheses(a, b = "hello", c = ["foo", "bar"], d = (2 + 2) * 2, e = {}) # test comment
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                            ^ meta.function.method.with-arguments.ruby punctuation.definition.parameters.ruby
+#                             ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                              ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                  ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                    ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.begin.ruby
+#                                     ^^^^^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby
+#                                          ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.end.ruby
+#                                           ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                             ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                               ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                                 ^ meta.function.method.with-arguments.ruby punctuation.section.array.begin.ruby
+#                                                  ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.begin.ruby
+#                                                   ^^^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby
+#                                                      ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.end.ruby
+#                                                       ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                         ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.begin.ruby
+#                                                          ^^^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby
+#                                                             ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.end.ruby
+#                                                              ^ meta.function.method.with-arguments.ruby punctuation.section.array.end.ruby
+#                                                               ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                                 ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                                                   ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                                                     ^ meta.function.method.with-arguments.ruby punctuation.section.function.begin.ruby
+#                                                                      ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                                                        ^ meta.function.method.with-arguments.ruby keyword.operator.arithmetic.ruby
+#                                                                          ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                                                           ^ meta.function.method.with-arguments.ruby punctuation.section.function.end.ruby
+#                                                                             ^ meta.function.method.with-arguments.ruby keyword.operator.arithmetic.ruby
+#                                                                               ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                                                                ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                                                  ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                                                                    ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                                                                      ^ meta.function.method.with-arguments.ruby punctuation.section.scope.begin.ruby
+#                                                                                       ^ meta.function.method.with-arguments.ruby punctuation.section.scope.end.ruby
+#                                                                                        ^ meta.function.method.with-arguments.ruby punctuation.definition.parameters.ruby
+#                                                                                          ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                                                                           ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+    hello, world = [1,2]
+#   ^^^^^ variable.other.ruby
+#        ^ punctuation.separator.object.ruby
+#          ^^^^^ variable.other.ruby
+#                ^ keyword.operator.assignment.ruby
+#                  ^ punctuation.section.array.begin.ruby
+#                   ^ constant.numeric.ruby
+#                    ^ punctuation.separator.object.ruby
+#                     ^ constant.numeric.ruby
+#                      ^ punctuation.section.array.end.ruby
+    do_something1
+#   ^^^^^^^^^^^^^ variable.other.ruby
+    do_something2
+#   ^^^^^^^^^^^^^ variable.other.ruby
+  end
+# ^^^ keyword.control.ruby
+
+
+  def method_with_parentheses(a,
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                            ^ meta.function.method.with-arguments.ruby punctuation.definition.parameters.ruby
+#                             ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                              ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+                              b = hello, # test comment
+#                             ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                               ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                 ^^^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                      ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                        ^ meta.function.method.with-arguments.ruby comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                         ^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby comment.line.number-sign.ruby
+                              c = ["foo", bar, :baz],
+#                             ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                               ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                 ^ meta.function.method.with-arguments.ruby punctuation.section.array.begin.ruby
+#                                  ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.begin.ruby
+#                                   ^^^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby
+#                                      ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.end.ruby
+#                                       ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                         ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                            ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                              ^ meta.function.method.with-arguments.ruby constant.language.symbol.ruby punctuation.definition.constant.ruby
+#                                               ^^^ meta.function.method.with-arguments.ruby constant.language.symbol.ruby
+#                                                  ^ meta.function.method.with-arguments.ruby punctuation.section.array.end.ruby
+#                                                   ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+                              d = (2 + 2) * 2,
+#                             ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                               ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                 ^ meta.function.method.with-arguments.ruby punctuation.section.function.begin.ruby
+#                                  ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                    ^ meta.function.method.with-arguments.ruby keyword.operator.arithmetic.ruby
+#                                      ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                       ^ meta.function.method.with-arguments.ruby punctuation.section.function.end.ruby
+#                                         ^ meta.function.method.with-arguments.ruby keyword.operator.arithmetic.ruby
+#                                           ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                            ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+
+                              e = {})
+#                             ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                               ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                 ^ meta.function.method.with-arguments.ruby punctuation.section.scope.begin.ruby
+#                                  ^ meta.function.method.with-arguments.ruby punctuation.section.scope.end.ruby
+#                                   ^ meta.function.method.with-arguments.ruby punctuation.definition.parameters.ruby
+
+    hello, world = [1,2]
+#   ^^^^^ variable.other.ruby
+#        ^ punctuation.separator.object.ruby
+#          ^^^^^ variable.other.ruby
+#                ^ keyword.operator.assignment.ruby
+#                  ^ punctuation.section.array.begin.ruby
+#                   ^ constant.numeric.ruby
+#                    ^ punctuation.separator.object.ruby
+#                     ^ constant.numeric.ruby
+#                      ^ punctuation.section.array.end.ruby
+    do_something1
+#   ^^^^^^^^^^^^^ variable.other.ruby
+    do_something2
+#   ^^^^^^^^^^^^^ variable.other.ruby
+  end
+# ^^^ keyword.control.ruby
+
+
+  def method_without_parentheses a, b, c = [foo,bar,baz]; hello, world = [1,2] end # test comment
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                                ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                 ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                   ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                    ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                      ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                        ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                          ^ meta.function.method.with-arguments.ruby punctuation.section.array.begin.ruby
+#                                           ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                              ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                               ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                                  ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                   ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                                      ^ meta.function.method.with-arguments.ruby punctuation.section.array.end.ruby
+#                                                       ^ punctuation.separator.statement.ruby
+#                                                         ^^^^^ variable.other.ruby
+#                                                              ^ punctuation.separator.object.ruby
+#                                                                ^^^^^ variable.other.ruby
+#                                                                      ^ keyword.operator.assignment.ruby
+#                                                                        ^ punctuation.section.array.begin.ruby
+#                                                                         ^ constant.numeric.ruby
+#                                                                          ^ punctuation.separator.object.ruby
+#                                                                           ^ constant.numeric.ruby
+#                                                                            ^ punctuation.section.array.end.ruby
+#                                                                              ^^^ keyword.control.ruby
+#                                                                                  ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                                                                   ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+
+
+  def method_without_parentheses a, b, c = [foo,bar,baz] # test comment
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                                ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                 ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                   ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                    ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                      ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                        ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                          ^ meta.function.method.with-arguments.ruby punctuation.section.array.begin.ruby
+#                                           ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                              ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                               ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                                  ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                   ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                                      ^ meta.function.method.with-arguments.ruby punctuation.section.array.end.ruby
+#                                                        ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                                         ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+    hello, world = [1,2]
+#   ^^^^^ variable.other.ruby
+#        ^ punctuation.separator.object.ruby
+#          ^^^^^ variable.other.ruby
+#                ^ keyword.operator.assignment.ruby
+#                  ^ punctuation.section.array.begin.ruby
+#                   ^ constant.numeric.ruby
+#                    ^ punctuation.separator.object.ruby
+#                     ^ constant.numeric.ruby
+#                      ^ punctuation.section.array.end.ruby
+  end
+# ^^^ keyword.control.ruby
+
+
+  def method_without_parentheses a, b = "hello", c = ["foo", "bar"], d = (2 + 2) * 2, e = "" # test comment
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                                ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                 ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                   ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                     ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                       ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.begin.ruby
+#                                        ^^^^^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby
+#                                             ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.end.ruby
+#                                              ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                                  ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                                    ^ meta.function.method.with-arguments.ruby punctuation.section.array.begin.ruby
+#                                                     ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.begin.ruby
+#                                                      ^^^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby
+#                                                         ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.end.ruby
+#                                                          ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                            ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.begin.ruby
+#                                                             ^^^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby
+#                                                                ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.end.ruby
+#                                                                 ^ meta.function.method.with-arguments.ruby punctuation.section.array.end.ruby
+#                                                                  ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                                    ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                                                      ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                                                        ^ meta.function.method.with-arguments.ruby punctuation.section.function.begin.ruby
+#                                                                         ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                                                           ^ meta.function.method.with-arguments.ruby keyword.operator.arithmetic.ruby
+#                                                                             ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                                                              ^ meta.function.method.with-arguments.ruby punctuation.section.function.end.ruby
+#                                                                                ^ meta.function.method.with-arguments.ruby keyword.operator.arithmetic.ruby
+#                                                                                  ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                                                                   ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                                                     ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                                                                       ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                                                                         ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.begin.ruby
+#                                                                                          ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.end.ruby
+#                                                                                            ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                                                                             ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+    hello, world = [1,2]
+#   ^^^^^ variable.other.ruby
+#        ^ punctuation.separator.object.ruby
+#          ^^^^^ variable.other.ruby
+#                ^ keyword.operator.assignment.ruby
+#                  ^ punctuation.section.array.begin.ruby
+#                   ^ constant.numeric.ruby
+#                    ^ punctuation.separator.object.ruby
+#                     ^ constant.numeric.ruby
+#                      ^ punctuation.section.array.end.ruby
+    do_something1
+#   ^^^^^^^^^^^^^ variable.other.ruby
+    do_something2
+#   ^^^^^^^^^^^^^ variable.other.ruby
+  end
+# ^^^ keyword.control.ruby
+
+
+  def method_without_parentheses a,    
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                                ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                 ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+                                b = "hello"  , # test comment
+#                               ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                 ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                   ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.begin.ruby
+#                                    ^^^^^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby
+#                                         ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.end.ruby
+#                                            ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                              ^ meta.function.method.with-arguments.ruby comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                               ^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby comment.line.number-sign.ruby
+                                c = ["foo", bar, :baz],
+#                               ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                 ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                   ^ meta.function.method.with-arguments.ruby punctuation.section.array.begin.ruby
+#                                    ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.begin.ruby
+#                                     ^^^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby
+#                                        ^ meta.function.method.with-arguments.ruby string.quoted.double.interpolated.ruby punctuation.definition.string.end.ruby
+#                                         ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                           ^^^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                              ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                                ^ meta.function.method.with-arguments.ruby constant.language.symbol.ruby punctuation.definition.constant.ruby
+#                                                 ^^^ meta.function.method.with-arguments.ruby constant.language.symbol.ruby
+#                                                    ^ meta.function.method.with-arguments.ruby punctuation.section.array.end.ruby
+#                                                     ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+                                d = (2 + 2) * 2,
+#                               ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                 ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                   ^ meta.function.method.with-arguments.ruby punctuation.section.function.begin.ruby
+#                                    ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                      ^ meta.function.method.with-arguments.ruby keyword.operator.arithmetic.ruby
+#                                        ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                         ^ meta.function.method.with-arguments.ruby punctuation.section.function.end.ruby
+#                                           ^ meta.function.method.with-arguments.ruby keyword.operator.arithmetic.ruby
+#                                             ^ meta.function.method.with-arguments.ruby constant.numeric.ruby
+#                                              ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+
+                                e = proc { |e| e + e }  
+#                               ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                 ^ meta.function.method.with-arguments.ruby keyword.operator.assignment.ruby
+#                                   ^^^^ meta.function.method.with-arguments.ruby support.function.kernel.ruby
+#                                        ^ meta.function.method.with-arguments.ruby punctuation.section.scope.begin.ruby
+#                                         ^ meta.function.method.with-arguments.ruby meta.syntax.ruby.start-block
+#                                          ^ meta.function.method.with-arguments.ruby meta.block.parameters.ruby punctuation.separator.variable.ruby
+#                                           ^ meta.function.method.with-arguments.ruby meta.block.parameters.ruby variable.other.block.ruby
+#                                            ^ meta.function.method.with-arguments.ruby meta.block.parameters.ruby punctuation.separator.variable.ruby
+#                                              ^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                                ^ meta.function.method.with-arguments.ruby keyword.operator.arithmetic.ruby
+#                                                  ^ meta.function.method.with-arguments.ruby variable.other.ruby
+#                                                    ^ meta.function.method.with-arguments.ruby punctuation.section.scope.end.ruby
+    hello, world = [1,2]
+#   ^^^^^ variable.other.ruby
+#        ^ punctuation.separator.object.ruby
+#          ^^^^^ variable.other.ruby
+#                ^ keyword.operator.assignment.ruby
+#                  ^ punctuation.section.array.begin.ruby
+#                   ^ constant.numeric.ruby
+#                    ^ punctuation.separator.object.ruby
+#                     ^ constant.numeric.ruby
+#                      ^ punctuation.section.array.end.ruby
+    do_something1
+#   ^^^^^^^^^^^^^ variable.other.ruby
+    do_something2
+#   ^^^^^^^^^^^^^ variable.other.ruby
+  end
+# ^^^ keyword.control.ruby
+
+
+  def method_without_parentheses *a, **b, &c; hello, world = [1,2] end # test comment
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                                ^ meta.function.method.with-arguments.ruby storage.type.variable.ruby
+#                                 ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                  ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                    ^^ meta.function.method.with-arguments.ruby storage.type.variable.ruby
+#                                      ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                       ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                         ^ meta.function.method.with-arguments.ruby storage.type.variable.ruby
+#                                          ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                           ^ punctuation.separator.statement.ruby
+#                                             ^^^^^ variable.other.ruby
+#                                                  ^ punctuation.separator.object.ruby
+#                                                    ^^^^^ variable.other.ruby
+#                                                          ^ keyword.operator.assignment.ruby
+#                                                            ^ punctuation.section.array.begin.ruby
+#                                                             ^ constant.numeric.ruby
+#                                                              ^ punctuation.separator.object.ruby
+#                                                               ^ constant.numeric.ruby
+#                                                                ^ punctuation.section.array.end.ruby
+#                                                                  ^^^ keyword.control.ruby
+#                                                                      ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                                                       ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+
+
+  def method_without_parentheses *a, **b, &c # test comment
+# ^^^ meta.function.method.with-arguments.ruby keyword.control.def.ruby
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.method.with-arguments.ruby entity.name.function.ruby
+#                                ^ meta.function.method.with-arguments.ruby storage.type.variable.ruby
+#                                 ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                  ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                    ^^ meta.function.method.with-arguments.ruby storage.type.variable.ruby
+#                                      ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                       ^ meta.function.method.with-arguments.ruby punctuation.separator.object.ruby
+#                                         ^ meta.function.method.with-arguments.ruby storage.type.variable.ruby
+#                                          ^ meta.function.method.with-arguments.ruby variable.parameter.function.ruby
+#                                            ^ comment.line.number-sign.ruby punctuation.definition.comment.ruby
+#                                             ^^^^^^^^^^^^^ comment.line.number-sign.ruby
+    hello, world = [1,2]
+#   ^^^^^ variable.other.ruby
+#        ^ punctuation.separator.object.ruby
+#          ^^^^^ variable.other.ruby
+#                ^ keyword.operator.assignment.ruby
+#                  ^ punctuation.section.array.begin.ruby
+#                   ^ constant.numeric.ruby
+#                    ^ punctuation.separator.object.ruby
+#                     ^ constant.numeric.ruby
+#                      ^ punctuation.section.array.end.ruby
+  end
+# ^^^ keyword.control.ruby


### PR DESCRIPTION
Fix for #663 

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/56965223/95683062-a2b92a80-0bf1-11eb-944f-078eea636da6.png">
</details>

<details>
<summary>After
</summary>
<img src="https://user-images.githubusercontent.com/56965223/95684789-8ec6f600-0bfc-11eb-844c-9ca4cca6000a.png">
</details>

No more leaking scopes
![Screenshot from 2020-10-11 20-00-50](https://user-images.githubusercontent.com/56965223/95684806-a1d9c600-0bfc-11eb-935c-2ac7b6c478ba.png)


Also added double splat operator.


- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run