### PR TITLE
fix: yard syntax

### DIFF
--- a/packages/vscode-ruby/syntaxes/ruby.cson.json
+++ b/packages/vscode-ruby/syntaxes/ruby.cson.json
@@ -2745,16 +2745,15 @@
 			]
 		},
 		"yard": {
-			"name": "comment.line.yard.ruby",
 			"patterns": [
 				{
 					"include": "#yard_comment"
 				},
 				{
-					"include": "#yard_name_types"
+					"include": "#yard_param_types"
 				},
 				{
-					"include": "#yard_param_types"
+					"include": "#yard_option"
 				},
 				{
 					"include": "#yard_tag"
@@ -2764,30 +2763,33 @@
 				},
 				{
 					"include": "#yard_directive"
+				},
+				{
+					"include": "#yard_see"
+				},
+				{
+					"include": "#yard_macro_attribute"
 				}
 			]
 		},
-		"yard_comment": {
-			"comment": "For YARD tags that follow the tag-comment pattern",
-			"begin": "^(\\s*)(#)(\\s*)(@)(abstract|api|author|deprecated|example|macro|note|overload|since|todo|version)(?=\\s|$)",
+		"yard_see": {
+			"comment": "separate rule for @see because name could contain url",
+			"begin": "^(\\s*)(#)(\\s*)(@)(see)(?=\\s)(\\s+(.+?))?(?=\\s|$)",
 			"beginCaptures": {
-				"1": {
-					"name": "comment.line.yard.ruby"
-				},
 				"2": {
 					"name": "punctuation.definition.comment.ruby"
-				},
-				"3": {
-					"name": "comment.line.yard.ruby"
 				},
 				"4": {
 					"name": "comment.line.keyword.punctuation.yard.ruby"
 				},
 				"5": {
 					"name": "comment.line.keyword.yard.ruby"
+				},
+				"7": {
+					"name": "comment.line.parameter.yard.ruby"
 				}
 			},
-			"end": "^(?!\\s*#\\3\\s{2,})",
+			"end": "^(?!\\s*#\\3\\s{2,}|\\s*#\\s*$)",
 			"contentName": "comment.line.string.yard.ruby",
 			"name": "comment.line.number-sign.ruby",
 			"patterns": [
@@ -2799,18 +2801,12 @@
 				}
 			]
 		},
-		"yard_name_types": {
-			"comment": "For YARD tags that follow the tag-name-types-comment pattern",
-			"begin": "^(\\s*)(#)(\\s*)(@)(attr|attr_reader|attr_writer|see|yieldparam)(?=\\s)(\\s+([a-z_][a-zA-Z_]*))?(\\s+((\\[).+(])))?",
+		"yard_macro_attribute": {
+			"comment": "separate rule for attribute and macro tags because name goes after []",
+			"begin": "^(\\s*)(#)(\\s*)(@!)(attribute|macro)(\\s+((\\[).+(])))?(?=\\s)(\\s+([a-z_]\\w*:?))?",
 			"beginCaptures": {
-				"1": {
-					"name": "comment.line.yard.ruby"
-				},
 				"2": {
 					"name": "punctuation.definition.comment.ruby"
-				},
-				"3": {
-					"name": "comment.line.yard.ruby"
 				},
 				"4": {
 					"name": "comment.line.keyword.punctuation.yard.ruby"
@@ -2818,26 +2814,46 @@
 				"5": {
 					"name": "comment.line.keyword.yard.ruby"
 				},
-				"6": {
-					"name": "comment.line.yard.ruby"
-				},
 				"7": {
-					"name": "comment.line.parameter.yard.ruby"
-				},
-				"8": {
-					"name": "comment.line.yard.ruby"
-				},
-				"9": {
 					"name": "comment.line.type.yard.ruby"
 				},
-				"10": {
+				"8": {
+					"name": "comment.line.punctuation.yard.ruby"
+				},
+				"9": {
 					"name": "comment.line.punctuation.yard.ruby"
 				},
 				"11": {
-					"name": "comment.line.punctuation.yard.ruby"
+					"name": "comment.line.parameter.yard.ruby"
 				}
 			},
-			"end": "^(?!\\s*#\\3\\s{2,})",
+			"end": "^(?!\\s*#\\3\\s{2,}|\\s*#\\s*$)",
+			"contentName": "comment.line.string.yard.ruby",
+			"name": "comment.line.number-sign.ruby",
+			"patterns": [
+				{
+					"include": "#yard"
+				},
+				{
+					"include": "#yard_continuation"
+				}
+			]
+		},
+		"yard_comment": {
+			"comment": "For YARD tags that follow the tag-comment pattern",
+			"begin": "^(\\s*)(#)(\\s*)(@)(abstract|api|author|deprecated|example|macro|note|overload|since|todo|version)(?=\\s|$)",
+			"beginCaptures": {
+				"2": {
+					"name": "punctuation.definition.comment.ruby"
+				},
+				"4": {
+					"name": "comment.line.keyword.punctuation.yard.ruby"
+				},
+				"5": {
+					"name": "comment.line.keyword.yard.ruby"
+				}
+			},
+			"end": "^(?!\\s*#\\3\\s{2,}|\\s*#\\s*$)",
 			"contentName": "comment.line.string.yard.ruby",
 			"name": "comment.line.number-sign.ruby",
 			"patterns": [
@@ -2850,17 +2866,11 @@
 			]
 		},
 		"yard_param_types": {
-			"comment": "For YARD tags that follow the tag-param-types-comment pattern",
-			"begin": "^(\\s*)(#)(\\s*)(@)(option|param)(?=\\s)(\\s+([a-z_][a-zA-Z_]*:?))?(\\s+((\\[).+(])))?(\\s+(:[a-z_][a-zA-Z_]*))?",
+			"comment": "For YARD tags that follow the tag-name-types-description or tag-types-name-description pattern",
+			"begin": "^(\\s*)(#)(\\s*)(@)(attr|attr_reader|attr_writer|yieldparam|param)(?=\\s)(?>\\s+(?>([a-z_]\\w*:?)|((\\[).+(]))))?(?>\\s+(?>((\\[).+(]))|([a-z_]\\w*:?)))?",
 			"beginCaptures": {
-				"1": {
-					"name": "comment.line.yard.ruby"
-				},
 				"2": {
 					"name": "punctuation.definition.comment.ruby"
-				},
-				"3": {
-					"name": "comment.line.yard.ruby"
 				},
 				"4": {
 					"name": "comment.line.keyword.punctuation.yard.ruby"
@@ -2869,19 +2879,19 @@
 					"name": "comment.line.keyword.yard.ruby"
 				},
 				"6": {
-					"name": "comment.line.yard.ruby"
-				},
-				"7": {
 					"name": "comment.line.parameter.yard.ruby"
 				},
-				"8": {
-					"name": "comment.line.yard.ruby"
-				},
-				"9": {
+				"7": {
 					"name": "comment.line.type.yard.ruby"
 				},
-				"10": {
+				"8": {
 					"name": "comment.line.punctuation.yard.ruby"
+				},
+				"9": {
+					"name": "comment.line.punctuation.yard.ruby"
+				},
+				"10": {
+					"name": "comment.line.type.yard.ruby"
 				},
 				"11": {
 					"name": "comment.line.punctuation.yard.ruby"
@@ -2890,13 +2900,63 @@
 					"name": "comment.line.punctuation.yard.ruby"
 				},
 				"13": {
+					"name": "comment.line.parameter.yard.ruby"
+				}
+			},
+			"end": "^(?!\\s*#\\3\\s{2,}|\\s*#\\s*$)",
+			"contentName": "comment.line.string.yard.ruby",
+			"name": "comment.line.number-sign.ruby",
+			"patterns": [
+				{
+					"include": "#yard"
+				},
+				{
+					"include": "#yard_continuation"
+				}
+			]
+		},
+		"yard_option": {
+			"comment": "For YARD option tag that follow the tag-name-types-key-(value)-description pattern",
+			"begin": "^(\\s*)(#)(\\s*)(@)(option)(?=\\s)(?>\\s+([a-z_]\\w*:?))?(?>\\s+((\\[).+(])))?(?>\\s+((\\S*)))?(?>\\s+((\\().+(\\))))?",
+			"beginCaptures": {
+				"2": {
+					"name": "punctuation.definition.comment.ruby"
+				},
+				"4": {
+					"name": "comment.line.keyword.punctuation.yard.ruby"
+				},
+				"5": {
 					"name": "comment.line.keyword.yard.ruby"
+				},
+				"6": {
+					"name": "comment.line.parameter.yard.ruby"
+				},
+				"7": {
+					"name": "comment.line.type.yard.ruby"
+				},
+				"8": {
+					"name": "comment.line.punctuation.yard.ruby"
+				},
+				"9": {
+					"name": "comment.line.punctuation.yard.ruby"
+				},
+				"10": {
+					"name": "comment.line.keyword.yard.ruby"
+				},
+				"11": {
+					"name": "comment.line.hashkey.yard.ruby"
+				},
+				"12": {
+					"name": "comment.line.defaultvalue.yard.ruby"
+				},
+				"13": {
+					"name": "comment.line.punctuation.yard.ruby"
 				},
 				"14": {
 					"name": "comment.line.punctuation.yard.ruby"
 				}
 			},
-			"end": "^(?!\\s*#\\3\\s{2,})",
+			"end": "^(?!\\s*#\\3\\s{2,}|\\s*#\\s*$)",
 			"contentName": "comment.line.string.yard.ruby",
 			"name": "comment.line.number-sign.ruby",
 			"patterns": [
@@ -2912,14 +2972,8 @@
 			"comment": "For YARD tags that are just the tag",
 			"match": "^(\\s*)(#)(\\s*)(@)(private)$",
 			"captures": {
-				"1": {
-					"name": "comment.line.yard.ruby"
-				},
 				"2": {
 					"name": "punctuation.definition.comment.ruby"
-				},
-				"3": {
-					"name": "comment.line.yard.ruby"
 				},
 				"4": {
 					"name": "comment.line.keyword.punctuation.yard.ruby"
@@ -2934,23 +2988,14 @@
 			"comment": "For YARD tags that follow the tag-types-comment pattern",
 			"begin": "^(\\s*)(#)(\\s*)(@)(raise|return|yield(?:return)?)(?=\\s)(\\s+((\\[).+(])))?",
 			"beginCaptures": {
-				"1": {
-					"name": "comment.line.yard.ruby"
-				},
 				"2": {
 					"name": "punctuation.definition.comment.ruby"
-				},
-				"3": {
-					"name": "comment.line.yard.ruby"
 				},
 				"4": {
 					"name": "comment.line.keyword.punctuation.yard.ruby"
 				},
 				"5": {
 					"name": "comment.line.keyword.yard.ruby"
-				},
-				"6": {
-					"name": "comment.line.yard.ruby"
 				},
 				"7": {
 					"name": "comment.line.type.yard.ruby"
@@ -2962,7 +3007,7 @@
 					"name": "comment.line.punctuation.yard.ruby"
 				}
 			},
-			"end": "^(?!\\s*#\\3\\s{2,})",
+			"end": "^(?!\\s*#\\3\\s{2,}|\\s*#\\s*$)",
 			"contentName": "comment.line.string.yard.ruby",
 			"name": "comment.line.number-sign.ruby",
 			"patterns": [
@@ -2976,25 +3021,16 @@
 		},
 		"yard_directive": {
 			"comment": "For YARD directives",
-			"begin": "^(\\s*)(#)(\\s*)(@!)(attribute|endgroup|group|macro|method|parse|scope|visibility)(\\s+((\\[).+(])))?(?=\\s)",
+			"begin": "^(\\s*)(#)(\\s*)(@!)(endgroup|group|method|parse|scope|visibility)(\\s+((\\[).+(])))?(?=\\s)",
 			"beginCaptures": {
-				"1": {
-					"name": "comment.line.yard.ruby"
-				},
 				"2": {
 					"name": "punctuation.definition.comment.ruby"
-				},
-				"3": {
-					"name": "comment.line.yard.ruby"
 				},
 				"4": {
 					"name": "comment.line.keyword.punctuation.yard.ruby"
 				},
 				"5": {
 					"name": "comment.line.keyword.yard.ruby"
-				},
-				"6": {
-					"name": "comment.line.yard.ruby"
 				},
 				"7": {
 					"name": "comment.line.type.yard.ruby"
@@ -3006,7 +3042,7 @@
 					"name": "comment.line.punctuation.yard.ruby"
 				}
 			},
-			"end": "^(?!\\s*#\\3\\s{2,})",
+			"end": "^(?!\\s*#\\3\\s{2,}|\\s*#\\s*$)",
 			"contentName": "comment.line.string.yard.ruby",
 			"name": "comment.line.number-sign.ruby",
 			"patterns": [

--- a/packages/vscode-ruby/test/yard.rb
+++ b/packages/vscode-ruby/test/yard.rb
@@ -1,0 +1,421 @@
+# SYNTAX TEST "source.ruby"
+  # @author Full Name
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^ comment.line.keyword.yard.ruby
+#          ^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @abstract
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^^ comment.line.keyword.yard.ruby
+  # @since 0.6.0
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^ comment.line.keyword.yard.ruby
+#         ^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @api private
+  # @attr attribute_name [Types] a full description of the attribute
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^ comment.line.keyword.yard.ruby
+#         ^^^^^^^^^^^^^^ comment.line.parameter.yard.ruby
+#                        ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                         ^^^^^ comment.line.type.yard.ruby
+#                              ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @attr [Types] attribute_name a full description of the attribute
+#         ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#          ^^^^^ comment.line.type.yard.ruby
+#               ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                 ^^^^^^^^^^^^^^ comment.line.parameter.yard.ruby
+#                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @attr_reader name [Types] description of a readonly attribute
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^^^^^ comment.line.keyword.yard.ruby
+#                ^^^^ comment.line.parameter.yard.ruby
+#                     ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                      ^^^^^ comment.line.type.yard.ruby
+#                           ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @attr_reader [Types] name description of a readonly attribute
+#                ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                 ^^^^^ comment.line.type.yard.ruby
+#                      ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                        ^^^^ comment.line.parameter.yard.ruby
+#                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+
+  # @attr_writer name [Types] description of writeonly attribute
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^^^^^ comment.line.keyword.yard.ruby
+#                ^^^^ comment.line.parameter.yard.ruby
+#                     ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                      ^^^^^ comment.line.type.yard.ruby
+#                           ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+
+  # @attr_writer [Types] name description of writeonly attribute
+#                ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                 ^^^^^ comment.line.type.yard.ruby
+#                      ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                        ^^^^ comment.line.parameter.yard.ruby
+  #
+  # @see http://example.com Description of URL
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^ comment.line.keyword.yard.ruby
+#        ^^^^^^^^^^^^^^^^^^ comment.line.parameter.yard.ruby
+#                          ^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @see SomeOtherClass#method
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^ comment.line.keyword.yard.ruby
+#        ^^^^^^^^^^^^^^^^^^^^^ comment.line.parameter.yard.ruby
+  #
+  # @deprecated Use {#my_new_method} instead of this method because
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^^^^ comment.line.keyword.yard.ruby
+#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   it uses a library that is no longer supported in Ruby 1.9. 
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   The new method accepts the same parameters.
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @abstract
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^^ comment.line.keyword.yard.ruby
+  # @private
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^ comment.line.keyword.yard.ruby
+  #
+  # @param opts [Hash] the options to create a message with.
+  # @option opts [String] :subject! The subject
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^ comment.line.keyword.yard.ruby
+#           ^^^^ comment.line.parameter.yard.ruby
+#                ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                 ^^^^^^ comment.line.type.yard.ruby
+#                       ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                         ^^^^^^^^^ comment.line.keyword.yard.ruby comment.line.hashkey.yard.ruby
+#                                  ^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @option opts [String] :from? ('nobody') From address
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^ comment.line.keyword.yard.ruby
+#           ^^^^ comment.line.parameter.yard.ruby
+#                ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                 ^^^^^^ comment.line.type.yard.ruby
+#                       ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                         ^^^^^^ comment.line.keyword.yard.ruby comment.line.hashkey.yard.ruby
+#                                ^ comment.line.defaultvalue.yard.ruby comment.line.punctuation.yard.ruby
+#                                 ^^^^^^^^ comment.line.defaultvalue.yard.ruby
+#                                         ^ comment.line.defaultvalue.yard.ruby comment.line.punctuation.yard.ruby
+#                                          ^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+
+  # @option opts [String] :to_ Recipient email
+  # @option opts [String] :body ('') The email's body
+  # @option opts1 [String] :sha256 ('') The email's body
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^ comment.line.keyword.yard.ruby
+#           ^^^^^ comment.line.parameter.yard.ruby
+#                 ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                  ^^^^^^ comment.line.type.yard.ruby
+#                        ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                          ^^^^^^^ comment.line.keyword.yard.ruby comment.line.hashkey.yard.ruby
+#                                  ^ comment.line.defaultvalue.yard.ruby comment.line.punctuation.yard.ruby
+#                                   ^^ comment.line.defaultvalue.yard.ruby
+#                                     ^ comment.line.defaultvalue.yard.ruby comment.line.punctuation.yard.ruby
+#                                      ^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @param (see User#initialize)
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^ comment.line.keyword.yard.ruby
+#         ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @param opts [OptionParser] the option parser object
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^ comment.line.keyword.yard.ruby
+#          ^^^^ comment.line.parameter.yard.ruby
+#               ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                ^^^^^^^^^^^^ comment.line.type.yard.ruby
+#                            ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @param [OptionParser] opts the option parser object
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^ comment.line.keyword.yard.ruby
+#          ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#           ^^^^^^^^^^^^ comment.line.type.yard.ruby
+#                       ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                         ^^^^ comment.line.parameter.yard.ruby
+#                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @param args [Array<String>] the arguments passed from input. This
+  #   array will be modified.
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+
+  # @param list [Array<String, Symbol>] the list of strings and symbols.
+  #
+  # @example Reverse a string
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^ comment.line.keyword.yard.ruby
+#           ^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   "mystring.reverse" #=> "gnirtsym"
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  #   multiline with empty line wihout spaces
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @example Parse a glob of files
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^ comment.line.keyword.yard.ruby
+#           ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   YARD.parse('lib/**/*.rb')
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @note This method may modify our application state!
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^ comment.line.keyword.yard.ruby
+
+  #  
+  # @raise [ExceptionClass] description
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^ comment.line.keyword.yard.ruby
+#          ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#           ^^^^^^^^^^^^^^ comment.line.type.yard.ruby
+#                         ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                          ^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @return [optional, types, ...] description
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^ comment.line.keyword.yard.ruby
+#           ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#            ^^^^^^^^^^^^^^^^^^^^ comment.line.type.yard.ruby
+#                                ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                                 ^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @return [true] always returns true
+  # @return [void]
+  # @return [String, nil] the contents of our object o# @api private
+  # @return the object
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^ comment.line.keyword.yard.ruby
+#          ^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @todo Add support for Jabberwocky service
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^ comment.line.keyword.yard.ruby
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   There is an open source Jabberwocky library available 
+  #   at http://somesite.com that can be integrated easily
+  #   into the project.
+  #
+  # for block {|a, b, c| ... }
+  # @yield [a, b, c] Description of block
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^ comment.line.keyword.yard.ruby
+#          ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#           ^^^^^^^ comment.line.type.yard.ruby
+#                  ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                   ^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @yieldparam name [String] the name that is yielded
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^^^^ comment.line.keyword.yard.ruby
+#               ^^^^ comment.line.parameter.yard.ruby
+#                    ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                     ^^^^^^ comment.line.type.yard.ruby
+#                           ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @yieldparam [String] name the name that is yielded
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^^^^ comment.line.keyword.yard.ruby
+#               ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                ^^^^^^ comment.line.type.yard.ruby
+#                      ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                        ^^^^ comment.line.parameter.yard.ruby
+#                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @yieldreturn [Fixnum] the number to add 5 to.
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^^^^^ comment.line.keyword.yard.ruby
+#                ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                 ^^^^^^ comment.line.type.yard.ruby
+#                       ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                        ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @overload set(key, value)
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^^ comment.line.keyword.yard.ruby
+#            ^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   Sets a value on key
+  #   @param key [Symbol] describe key param
+#     ^ comment.line.keyword.punctuation.yard.ruby
+#      ^^^^^ comment.line.keyword.yard.ruby
+#            ^^^ comment.line.parameter.yard.ruby
+#                ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                 ^^^^^^ comment.line.type.yard.ruby
+#                       ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                        ^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   @param [Object] value describe value param
+#     ^ comment.line.keyword.punctuation.yard.ruby
+#      ^^^^^ comment.line.keyword.yard.ruby
+#            ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#             ^^^^^^ comment.line.type.yard.ruby
+#                   ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                     ^^^^^ comment.line.parameter.yard.ruby
+#                          ^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @overload set(value)
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^^ comment.line.keyword.yard.ruby
+#            ^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   Sets a value on the default key +:foo+
+  #   @param value [Object] describe value param
+#     ^ comment.line.keyword.punctuation.yard.ruby
+#      ^^^^^ comment.line.keyword.yard.ruby
+#            ^^^^^ comment.line.parameter.yard.ruby
+#                  ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                   ^^^^^^ comment.line.type.yard.ruby
+#                         ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                          ^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @version 2.0
+# ^ punctuation.definition.comment.ruby
+#   ^ comment.line.keyword.punctuation.yard.ruby
+#    ^^^^^^^ comment.line.keyword.yard.ruby
+#           ^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # Simple readonly attribute
+  # @!attribute [r] count
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^^^^^ comment.line.keyword.yard.ruby
+#               ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                ^ comment.line.type.yard.ruby
+#                 ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                   ^^^^^ comment.line.number-sign.ruby comment.line.parameter.yard.ruby
+  #   @return [Fixnum] the size of the list
+#     ^ comment.line.keyword.punctuation.yard.ruby
+#      ^^^^^^ comment.line.keyword.yard.ruby
+#             ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#              ^^^^^^ comment.line.type.yard.ruby
+#                    ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                     ^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # Simple writeonly attribute
+  # @!attribute [w] last_name
+  #   @return [Fixnum] the last_name of the user
+  #
+  # Simple readwrite attribute
+  # @!attribute name
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^^^^^ comment.line.keyword.yard.ruby
+#               ^^^^ comment.line.number-sign.ruby comment.line.parameter.yard.ruby
+  #   @return [String] the name of the user
+# ^ punctuation.definition.comment.ruby
+#     ^ comment.line.keyword.punctuation.yard.ruby
+#      ^^^^^^ comment.line.keyword.yard.ruby
+#             ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#              ^^^^^^ comment.line.type.yard.ruby
+#                    ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                     ^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @!group Callbacks
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^ comment.line.keyword.yard.ruby
+#          ^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @!endgroup
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^^^^ comment.line.keyword.yard.ruby
+  #
+  # @!macro [attach] property
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^ comment.line.keyword.yard.ruby
+#           ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#            ^^^^^^ comment.line.type.yard.ruby
+#                  ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                    ^^^^^^^^ comment.line.number-sign.ruby comment.line.parameter.yard.ruby
+  #   @return [$2] the $1 property
+# ^ punctuation.definition.comment.ruby
+#     ^ comment.line.keyword.punctuation.yard.ruby
+#      ^^^^^^ comment.line.keyword.yard.ruby
+#             ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#              ^^ comment.line.type.yard.ruby
+#                ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                 ^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @!method quit(username, message = "Quit")
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^^ comment.line.keyword.yard.ruby
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   Sends a quit message to the server for a +username+.
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   @param username [String] the username to quit
+#     ^ comment.line.keyword.punctuation.yard.ruby
+#      ^^^^^ comment.line.keyword.yard.ruby
+#            ^^^^^^^^ comment.line.parameter.yard.ruby
+#                     ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                      ^^^^^^ comment.line.type.yard.ruby
+#                            ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                             ^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   @param message [String] the quit message
+#     ^ comment.line.keyword.punctuation.yard.ruby
+#      ^^^^^ comment.line.keyword.yard.ruby
+#            ^^^^^^^ comment.line.parameter.yard.ruby
+#                    ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                     ^^^^^^ comment.line.type.yard.ruby
+#                           ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#                            ^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # includes "UserMixin" and extends "UserMixin::ClassMethods"
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby
+  # using the UserMixin.included callback.
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby
+  # @!parse include UserMixin
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^ comment.line.keyword.yard.ruby
+#          ^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  # @!parse extend UserMixin::ClassMethods{}
+# ^ punctuation.definition.comment.ruby
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^ comment.line.keyword.yard.ruby
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @!parse [c]
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^ comment.line.keyword.yard.ruby
+#           ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+#            ^ comment.line.type.yard.ruby
+#             ^ comment.line.type.yard.ruby comment.line.punctuation.yard.ruby
+  #   void Init_Foo() {
+#  ^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #     rb_define_method(rb_cFoo, "method", method, 0);
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #   }
+#  ^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @!scope class
+# ^ punctuation.definition.comment.ruby
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^ comment.line.keyword.yard.ruby
+#          ^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby
+  #
+  # @!visibility private
+# ^ punctuation.definition.comment.ruby
+#   ^^ comment.line.keyword.punctuation.yard.ruby
+#     ^^^^^^^^^^ comment.line.keyword.yard.ruby
+#               ^^^^^^^^^ comment.line.number-sign.ruby comment.line.string.yard.ruby


### PR DESCRIPTION
Fix #560 
Changes:

- add separate rule for `@see` tag - first argument of this tag could be URL
- add separate rule for `@!attribute` and `@!macro` tags - in these tags name goes after brackets
- change end regex in rules - now you dont need to make indentations on dividing empty lines
- add numbers to parameter names in tags
- add numbers, trailing `?` and `!` to hash keys names in `@option` tag
- add additional scope to hash keys in @option tag `comment.line.hashkey.yard.ruby`

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run