### PR TITLE
Specify dependent config for formatting

### DIFF
--- a/packages/vscode-ruby-client/package.json
+++ b/packages/vscode-ruby-client/package.json
@@ -420,7 +420,7 @@
 						"rubyfmt"
 					],
 					"default": false,
-					"description": "Which system to use for formatting. Use `false` to disable or if another extension provides this feature.",
+					"description": "Which system to use for formatting. Use `false` to disable or if another extension provides this feature. Language server must be enabled for this option to take effect.",
 					"scope": "resource"
 				}
 			}


### PR DESCRIPTION
Why: Without the language server enabled the configured formatter does
not have any impact.

- [ ] The build passes
- [ ] TSLint is mostly happy
- [ ] Prettier has been run
