### PR TITLE
fix: default to login shell (`-l`) when opening a shell

### DIFF
--- a/packages/vscode-ruby-common/src/environment.ts
+++ b/packages/vscode-ruby-common/src/environment.ts
@@ -41,7 +41,7 @@ for name in (set -nx)
 	end
 end`;
 	} else {
-		template = `#!${shell} -i\nexport`;
+		template = `#!${shell} -i -l\nexport`;
 	}
 
 	return template;


### PR DESCRIPTION
Add the `-l` flag when opening a shell so that dotfiles are loaded. Fixes rvm not being loaded properly.
Fixes #620, #451 

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run