### PR TITLE
fix: maintain original EOL after formatting (issue #665)

### DIFF
--- a/packages/language-server-ruby/package.json
+++ b/packages/language-server-ruby/package.json
@@ -9,7 +9,9 @@
 	"main": "dist/index.js",
 	"dependencies": {
 		"cross-spawn": "^6.0.5",
+		"detect-newline": "^3.1.0",
 		"diff-match-patch": "^1.0.4",
+		"eol": "^0.9.1",
 		"loglevel": "^1.6.7",
 		"rxjs": "^6.4.0",
 		"vscode-languageserver": "^5.2.1",

--- a/packages/language-server-ruby/src/util/spawn.ts
+++ b/packages/language-server-ruby/src/util/spawn.ts
@@ -6,7 +6,7 @@ import log from 'loglevel';
 
 export type SpawnOpts = {
 	stdin?: Observable<string>;
-	encoding?: string;
+	encoding?: BufferEncoding;
 } & SpawnOptions;
 
 export interface SpawnReturn {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3704,6 +3704,11 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+detect-newline@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
 dezalgo@^1.0.0, dezalgo@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
@@ -3970,6 +3975,11 @@ envinfo@^7.3.1:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.2.tgz#098f97a0e902f8141f9150553c92dbb282c4cabe"
   integrity sha512-k3Eh5bKuQnZjm49/L7H4cHzs2FlL5QjbTB3JrPxoTI8aJG7hVMe4uKyJxSYH4ahseby2waUwk5OaKX/nAsaYgg==
+
+eol@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/eol/-/eol-0.9.1.tgz#f701912f504074be35c6117a5c4ade49cd547acd"
+  integrity sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==
 
 err-code@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
This implements a workaround for formatters that change the line endings of files.   This change looks to address two problems:

1. When a file in LF mode in VS Code and the formatter outputs CRLF, VS Code will convert the CRs inserted by the TextEdit objects as new LFs, thus producing double lines as seen in #665 and #644 
2. On Windows, Rubocop and Standardrb appear to have bugs that, on CRLF inputs, will produce CRCRLF inputs.  VS Code will convert the CRs inserted by the TextEdit objects as new CRLFs, similarly producing double lines.

Since changing the line ending type of the entire file doesn't seem possible by TextEdits alone, we can instead "undo" the line ending changes the formatters do, while still producing TextEdits of the other changes.

This approach works by determining which line ending the original file was in, and converting the output formatted text to that line ending before diffing the text and generating TextEdits.  

It is entirely possible there is a better approach, but I do not know enough about VS Code extension writing to do better yet.

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run