### PR TITLE
fix: when a setBreakpoint request comes in, always respond only once

### DIFF
--- a/packages/language-server-ruby/src/util/spawn.ts
+++ b/packages/language-server-ruby/src/util/spawn.ts
@@ -50,7 +50,7 @@ export function spawn<T = string>(
 				if (typeof b === 'string') {
 					chunk = b.toString();
 				} else {
-					chunk = b.toString(optsWithoutStdIn.encoding || 'utf8');
+					chunk = b.toString(<BufferEncoding> optsWithoutStdIn.encoding || 'utf8');
 				}
 			} catch (e) {
 				chunk = `<< Lost chunk of process output for ${cmd} - length was ${b.length}>>`;


### PR DESCRIPTION
*Description of change and why it was needed here*

Fixes https://github.com/rubyide/vscode-ruby/issues/510 and https://github.com/rubyide/vscode-ruby/issues/657

This fixes a notorious bug that engineers at Stripe encounter daily: The debugger fails to attach because they have a breakpoint that is unset in a file.

Specifically, the situation occurs when VS Code has one file open that has _all_ unset breakpoints (e.g., there are no active breakpoints in the file). It turns out that VS Code sends out a `setBreakpoints` request with _no_ breakpoints for this file. In this case, the Ruby debug adapter's code would not send a response to this request, so VS Code would wait forever for a response that would never come.

I've updated the code to ensure that it always responds once to this sort of request, and fixes another bug where I think it might respond twice to a single setBreakpoints request.

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run: I did not run prettier because the code I edited has never been prettiered, and I did not want to dirty the diff.