### PR TITLE
feat(prettier): add prettier management

### DIFF
--- a/packages/.eslintrc.base.json
+++ b/packages/.eslintrc.base.json
@@ -21,6 +21,6 @@
 				"allowHigherOrderFunctions": true
 			}
 		],
-		"@typescript-eslint/array-type": ["error", "array"]
+		"@typescript-eslint/array-type": ["error", { "default": "array" }]
 	}
 }

--- a/packages/language-server-ruby/src/Formatter.ts
+++ b/packages/language-server-ruby/src/Formatter.ts
@@ -18,6 +18,7 @@ import {
 	Standard,
 	Rufo,
 	RubyFMT,
+	Prettier,
 } from './formatters';
 
 const FORMATTER_MAP = {
@@ -25,6 +26,7 @@ const FORMATTER_MAP = {
 	standard: Standard,
 	rufo: Rufo,
 	rubyfmt: RubyFMT,
+	prettier: Prettier,
 };
 
 function getFormatter(

--- a/packages/language-server-ruby/src/SettingsCache.ts
+++ b/packages/language-server-ruby/src/SettingsCache.ts
@@ -28,7 +28,7 @@ export interface RubyConfiguration extends RubyCommandConfiguration {
 		reek?: boolean | RubyConfiguration;
 		rubocop?: boolean | RuboCopLintConfiguration;
 	};
-	format: boolean | 'rubocop' | 'standard' | 'rufo';
+	format: boolean | 'rubocop' | 'standard' | 'rufo' | 'prettier';
 	languageServer: {
 		logLevel: LogLevelDesc;
 	};

--- a/packages/language-server-ruby/src/formatters/BaseFormatter.ts
+++ b/packages/language-server-ruby/src/formatters/BaseFormatter.ts
@@ -73,12 +73,10 @@ export default abstract class BaseFormatter implements IFormatter {
 			stdin: of(this.originalText),
 		}).pipe(
 			catchError(error => {
-				console.log(error);
 				const err: Error | null = this.processError(error, formatStr);
 				return err ? throwError(err) : of('');
 			}),
 			reduce((acc: string, value: any) => {
-				console.log(value);
 				if (value.source === 'stdout') {
 					return `${acc}${value.text}`;
 				} else {

--- a/packages/language-server-ruby/src/formatters/BaseFormatter.ts
+++ b/packages/language-server-ruby/src/formatters/BaseFormatter.ts
@@ -26,9 +26,9 @@ export interface FormatterConfig {
 
 export default abstract class BaseFormatter implements IFormatter {
 	protected document: TextDocument;
-	private originalText: string;
+	private readonly originalText: string;
 	protected config: FormatterConfig;
-	private differ: DiffMatchPatch;
+	private readonly differ: DiffMatchPatch;
 
 	constructor(document: TextDocument, config: FormatterConfig) {
 		this.document = document;
@@ -73,10 +73,12 @@ export default abstract class BaseFormatter implements IFormatter {
 			stdin: of(this.originalText),
 		}).pipe(
 			catchError(error => {
+				console.log(error);
 				const err: Error | null = this.processError(error, formatStr);
 				return err ? throwError(err) : of('');
 			}),
 			reduce((acc: string, value: any) => {
+				console.log(value);
 				if (value.source === 'stdout') {
 					return `${acc}${value.text}`;
 				} else {

--- a/packages/language-server-ruby/src/formatters/Prettier.ts
+++ b/packages/language-server-ruby/src/formatters/Prettier.ts
@@ -1,0 +1,47 @@
+import cp from 'child_process';
+import { URI } from 'vscode-uri';
+import BaseFormatter from './BaseFormatter';
+
+enum PrettierKind {
+	RbPrettier = 'rbprettier',
+	Prettier = 'prettier',
+}
+
+export default class Prettier extends BaseFormatter {
+	private _cmd: string = '';
+
+	get cmd(): string {
+		if (this._cmd === '') return this.buildCmd();
+		return this._cmd;
+	}
+
+	get args(): string[] {
+		const documentPath = URI.parse(this.document.uri);
+		return [`${documentPath.fsPath}`];
+	}
+
+	private buildCmd(): string {
+		let prettierExecutable = this.getPrettierExecutable();
+		if (prettierExecutable === PrettierKind.RbPrettier) {
+			this._cmd = prettierExecutable;
+			return prettierExecutable;
+		}
+
+		prettierExecutable = this.isWindows() ? prettierExecutable + '.bat' : prettierExecutable;
+		this._cmd = prettierExecutable;
+		return prettierExecutable;
+	}
+
+	private getPrettierExecutable(): string {
+		let args = [];
+		if (this.useBundler) {
+			args = [...args, 'bundle', 'exec'];
+		}
+		args = [...args, 'rbprettier', '--version'];
+		const rbPrettierCommand = args.shift();
+		const rbPrettierProcess = cp.spawnSync(rbPrettierCommand, args);
+		if (rbPrettierProcess.stderr.length !== 0) return PrettierKind.Prettier;
+
+		return PrettierKind.RbPrettier;
+	}
+}

--- a/packages/language-server-ruby/src/formatters/index.ts
+++ b/packages/language-server-ruby/src/formatters/index.ts
@@ -4,3 +4,4 @@ export { default as RuboCop } from './RuboCop';
 export { default as Rufo } from './Rufo';
 export { default as Standard } from './Standard';
 export { default as RubyFMT } from './RubyFMT';
+export { default as Prettier } from './Prettier';

--- a/packages/vscode-ruby-client/README.md
+++ b/packages/vscode-ruby-client/README.md
@@ -10,7 +10,7 @@ This extension provides enhanced Ruby language and debugging support for Visual 
 
 - Automatic Ruby environment detection with support for rvm, rbenv, chruby, and asdf
 - Lint support via RuboCop, Standard, and Reek
-- Format support via RuboCop, Standard, Rufo, and RubyFMT
+- Format support via RuboCop, Standard, Rufo, Prettier and RubyFMT
 - Semantic code folding support
 - Semantic highlighting support
 - Basic Intellisense support

--- a/packages/vscode-ruby-client/package.json
+++ b/packages/vscode-ruby-client/package.json
@@ -417,7 +417,8 @@
 						"rubocop",
 						"standard",
 						"rufo",
-						"rubyfmt"
+						"rubyfmt",
+						"prettier"
 					],
 					"default": false,
 					"description": "Which system to use for formatting. Use `false` to disable or if another extension provides this feature.",


### PR DESCRIPTION
Requested by https://github.com/rubyide/vscode-ruby/issues/681. [Prettier for ruby](https://github.com/prettier/plugin-ruby) has been released some weeks ago, would be nice if vscode-ruby can manage it !

- [x] The build passes
- [x] ESLint is mostly happy
- [x] Prettier has been run