### PR TITLE
Fix infinite crawl with symbolic link directory using lstat

### DIFF
--- a/packages/vscode-ruby-client/src/locate/locate.js
+++ b/packages/vscode-ruby-client/src/locate/locate.js
@@ -165,7 +165,7 @@ export class Locate {
 	_walkNode(dir, file, callback) {
 		const absPath = path.join(dir, file);
 		const relPath = path.relative(this.root, absPath);
-		fs.stat(absPath, (err, stats) => {
+		fs.lstat(absPath, (err, stats) => {
 			if (err) {
 				callback(err);
 				return;


### PR DESCRIPTION
If a directory contains a symbolic link to itself, the extension will forever get stuck "Indexing Ruby source files". The default behavior of `stat` will resolve symbolic links to the referenced file, so `_walkDir` will continuously add itself to the walk queue. Using `lstat` will ensure that `isDirectory` will return `false` for a symbolic link.

>`lstat()` is identical to `stat()`, except that if `path` is a symbolic link, then the link itself is stat-ed, not the file that it refers to.

https://nodejs.org/api/fs.html#fs_fs_lstat_path_options_callback

Steps to reproduce:

```
ln -s . example
```

Alternative / Open question: Would it be desirable to crawl symlinked directories? If so, maybe an alternative solution here could be to keep a `Set` of crawled directories, and check that a directory has not already been added to the queue before pushing it?

- [ ] The build passes
- [ ] TSLint is mostly happy
- [ ] Prettier has been run