### PR TITLE
Fix some typos

### DIFF
--- a/packages/vscode-ruby/syntaxes/ruby.cson.json
+++ b/packages/vscode-ruby/syntaxes/ruby.cson.json
@@ -333,7 +333,7 @@
 					"name": "punctuation.definition.symbol.begin.ruby"
 				}
 			},
-			"comment": "symbol literal with '' delimitor",
+			"comment": "symbol literal with '' delimiter",
 			"end": "'",
 			"endCaptures": {
 				"0": {
@@ -355,7 +355,7 @@
 					"name": "punctuation.section.symbol.begin.ruby"
 				}
 			},
-			"comment": "symbol literal with \"\" delimitor",
+			"comment": "symbol literal with \"\" delimiter",
 			"end": "\"",
 			"endCaptures": {
 				"0": {
@@ -384,7 +384,7 @@
 					"name": "punctuation.definition.string.begin.ruby"
 				}
 			},
-			"comment": "string literal with '' delimitor",
+			"comment": "string literal with '' delimiter",
 			"end": "'",
 			"endCaptures": {
 				"0": {
@@ -406,7 +406,7 @@
 					"name": "punctuation.definition.string.begin.ruby"
 				}
 			},
-			"comment": "string literal with interpolation and \"\" delimitor",
+			"comment": "string literal with interpolation and \"\" delimiter",
 			"end": "\"",
 			"endCaptures": {
 				"0": {

--- a/packages/vscode-ruby/syntaxes/ruby.cson.json
+++ b/packages/vscode-ruby/syntaxes/ruby.cson.json
@@ -817,7 +817,7 @@
 			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
-					"comment": "Cant be named because its not neccesarily an escape.",
+					"comment": "Cant be named because its not necessarily an escape.",
 					"match": "\\\\."
 				}
 			]
@@ -1061,7 +1061,7 @@
 			"name": "string.quoted.other.ruby",
 			"patterns": [
 				{
-					"comment": "Cant be named because its not neccesarily an escape.",
+					"comment": "Cant be named because its not necessarily an escape.",
 					"match": "\\\\."
 				}
 			]
@@ -1328,7 +1328,7 @@
 			"name": "string.quoted.other.ruby",
 			"patterns": [
 				{
-					"comment": "Cant be named because its not neccesarily an escape.",
+					"comment": "Cant be named because its not necessarily an escape.",
 					"match": "\\\\."
 				}
 			]
@@ -1445,7 +1445,7 @@
 			"name": "constant.language.symbol.ruby",
 			"patterns": [
 				{
-					"comment": "Cant be named because its not neccesarily an escape.",
+					"comment": "Cant be named because its not necessarily an escape.",
 					"match": "\\\\."
 				}
 			]

--- a/packages/vscode-ruby/syntaxes/ruby.cson.json
+++ b/packages/vscode-ruby/syntaxes/ruby.cson.json
@@ -373,7 +373,7 @@
 			]
 		},
 		{
-			"comment": "Needs higher precidence than regular expressions.",
+			"comment": "Needs higher precedence than regular expressions.",
 			"match": "(?<!\\()/=",
 			"name": "keyword.operator.assignment.augmented.ruby"
 		},


### PR DESCRIPTION
When I'm digging a syntax highlight issue, found these typos. 😄 

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run