### PR TITLE
Use ruby/setup-ruby instead of deprecated one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         ruby: [2.4, 2.5, 2.6, 2.7]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - uses: actions/setup-node@v1
@@ -149,7 +149,7 @@ jobs:
       - name: Install Dependencies
         # if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install ruby-debug-ide and debase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install ruby-debug-ide and debase
-        run: gem install ruby-debug-ide debase -N
+        run: gem install ruby-debug-ide debase -N --prerelease
       - name: Build debugger
         run: yarn build
         working-directory: packages/vscode-ruby-debugger


### PR DESCRIPTION
https://github.com/rubyide/vscode-ruby/runs/2107273120 fails with following message

```
Run actions/setup-ruby@v1
  with:
    ruby-version: 2.4
------------------------
NOTE: This action is deprecated and is no longer maintained.
Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
------------------------
Error: Version 2.4 not found
```

So just tried to use it... 🤔 