### PR TITLE
Fix syntax highlighting for empty block parameter

### DIFF
--- a/packages/vscode-ruby/syntaxes/ruby.cson.json
+++ b/packages/vscode-ruby/syntaxes/ruby.cson.json
@@ -2085,7 +2085,7 @@
 					"name": "punctuation.separator.variable.ruby"
 				}
 			},
-			"end": "(?<!\\|)(\\|)(?!\\|)",
+			"end": "(\\|)(?!\\|)",
 			"patterns": [
 				{
 					"begin": "(?![\\s,|(])",

--- a/packages/vscode-ruby/test/syntax.rb
+++ b/packages/vscode-ruby/test/syntax.rb
@@ -65,6 +65,13 @@ class ExampleClass < AnotherClass
 #           ^^ keyword.control.start-block.ruby
     end
 
+  [].each do ||
+    #   ^ punctuation.section.array.begin.ruby
+    #    ^ punctuation.section.array.end.ruby
+    #           ^^ keyword.control.start-block.ruby
+  end
+# ^^^ keyword.control.ruby
+
   end
 
   def true?(obj)


### PR DESCRIPTION
This PR tries to fix following syntax highlight issue.
I found this issue when interested  https://github.com/ruby/ruby/blob/7d4a3ac0c5a004a410c425d334975e09420f47cd/test/ruby/test_module.rb#L561-L572

Before
---

<img width="134" alt="スクリーンショット 2021-03-15 21 46 48" src="https://user-images.githubusercontent.com/1180335/111155590-fc29e900-85d7-11eb-8414-570460588411.png">

<img width="623" alt="スクリーンショット 2021-03-15 21 46 27" src="https://user-images.githubusercontent.com/1180335/111155581-f9c78f00-85d7-11eb-9a5d-6f86f65701f8.png">

After
---

<img width="145" alt="スクリーンショット 2021-03-15 21 35 07" src="https://user-images.githubusercontent.com/1180335/111154308-70fc2380-85d6-11eb-9268-18421888d41e.png">

<img width="456" alt="スクリーンショット 2021-03-15 21 44 53" src="https://user-images.githubusercontent.com/1180335/111155383-ba00a780-85d7-11eb-8211-f83c4fc988f9.png">

🤔 
---

Honestly, I'm not well for Ruby syntax and how to highlight them in VSCode.
I don't have confident this PR breaks other important behaviors or not 😓 
So I have created an experimental fork as https://marketplace.visualstudio.com/items?itemName=kachick.vscode-ruby-experimental to ensure the behavior.

When this patch has crucial problem, please tell me :bow:

---

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run