### PR TITLE
Run linters from workspace root

### DIFF
--- a/packages/language-server-ruby/src/Linter.ts
+++ b/packages/language-server-ruby/src/Linter.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { URI } from 'vscode-uri';
 import { iif, from, forkJoin, of, Observable } from 'rxjs';
 import { map, mergeMap, switchMap } from 'rxjs/operators';
@@ -40,7 +39,7 @@ function getLinter(
 	if (!linter) return new NullLinter(`attempted to lint with unsupported linter: ${name}`);
 	const lintConfig: RubyCommandConfiguration =
 		typeof config.lint[name] === 'object' ? config.lint[name] : {};
-	const executionRoot = path.dirname(URI.parse(document.uri).fsPath);
+	const executionRoot = URI.parse(config.workspaceFolderUri).fsPath;
 	const linterConfig: LinterConfig = {
 		env,
 		executionRoot,


### PR DESCRIPTION
Fixes #717.

- [x] The build passes
- [ ] TSLint is mostly happy — It was already unhappy. This PR doesn't make it _more_ unhappy.
- [ ] Prettier has been run — Not possible because TSLint was already unhappy through no fault of this PR.