### PR TITLE
Pass valid filenames to RuboCop and Reek

### DIFF
--- a/packages/language-server-ruby/src/linters/Reek.ts
+++ b/packages/language-server-ruby/src/linters/Reek.ts
@@ -27,7 +27,7 @@ export default class Reek extends BaseLinter {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		return ['-f', 'json', '--stdin-filename', `'${documentPath.fsPath}'`];
+		return ['-f', 'json', '--stdin-filename', documentPath.fsPath];
 	}
 
 	protected processResults(data): Diagnostic[] {

--- a/packages/language-server-ruby/src/linters/RuboCop.ts
+++ b/packages/language-server-ruby/src/linters/RuboCop.ts
@@ -58,7 +58,7 @@ export default class RuboCop extends BaseLinter {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		let args = ['-s', `'${documentPath.fsPath}'`, '-f', 'json'];
+		let args = ['-s', documentPath.fsPath, '-f', 'json'];
 		if (this.lintConfig.rails) args.push('-R');
 		if (this.lintConfig.forceExclusion) args.push('--force-exclusion');
 		if (this.lintConfig.lint) args.push('-l');


### PR DESCRIPTION
Fixes bug #719.

- [x] The build passes
- [ ] TSLint is mostly happy — It was already unhappy. This PR doesn't make it _more_ unhappy.
- [ ] Prettier has been run — Not possible because TSLint was already unhappy through no fault of this PR.