### PR TITLE
fix(rubocop): add `forceExclusion` to extension configuration

### DIFF
--- a/packages/vscode-ruby-client/package.json
+++ b/packages/vscode-ruby-client/package.json
@@ -287,6 +287,11 @@
 									"type": "string",
 									"description": "RuboCop command. Setting this will cause RuboCop to be executed this way and other settings will be ignored!"
 								},
+								"forceExclusion": {
+									"type": "boolean",
+									"default": false,
+									"description": "Add the `--force-exclusion` option to the RuboCop command to prevent running RuboCop on the excluded files from rubocop.yml."
+								},
 								"useBundler": {
 									"type": "boolean",
 									"default": false,


### PR DESCRIPTION
The `forceExclusion` option was added in b5cb94b88dc514a484d82e439ae6090cf4a8ca2f but not added to the extension configuration. Therefore, VSCode did not suggest this property when editing the configuration.

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run