### PR TITLE
feat: add skipFiles and showDebuggerCommands

### DIFF
--- a/docs/debugger.md
+++ b/docs/debugger.md
@@ -26,6 +26,32 @@ Read following instructions about how to debug ruby/rails/etc locally or remotel
 
 ## Debugger F.A.Q.
 
+Q: What's the difference between 'skipFiles' and 'finishFiles'?  
+A: The debugger will automatically step through skipFiles, whereas it will automatically step out of finishFiles.
+
+Q: What are skipFiles and finishFiles useful for?  
+A: They are two different tools for avoiding parts of the code while stepping. skipFiles helps you skip stack frames that sit between frames that you are interested in (e.g. [https://sorbet.org/](sorbet)). finishFiles, on the other hand, help you avoid stack frames (and everything deeper than them) entirely.
+
+Q: Can I see an example?  
+A: In the listing below, assume the debugger is suspended at line 2. Here's what happens if you 'Step Into' (F11) when...
+
+* `b.rb` is in neither: the debugger suspends at line 5.
+* `b.rb` is in `skipFiles`: the program prints "1" then the debugger suspends at line 9.
+* `b.rb` is in `finishFiles`: the program prints "12" then the debugger suspends at line 3. 
+
+```
+1:   def methodA
+2: =>  methodB
+3:     puts "3"
+# Assume methodB is in b.rb
+4:   def methodB:
+5:     puts "1"
+6:     methodC
+# Assume methodC is in c.rb
+8:   def methodC:
+9:     puts "2"
+```
+
 ### Conditional breakpoint doesn't work
 
 You need use Ruby `2.0` or above and you need to update `debase` to latest beta version `gem install debase -v 0.2.2.beta10`.

--- a/packages/vscode-ruby-client/package.json
+++ b/packages/vscode-ruby-client/package.json
@@ -615,6 +615,21 @@
 								"description": "Show output of the debugger in the console.",
 								"default": false
 							},
+							"showDebuggerCommands": {
+								"type": "boolean",
+								"description": "Show commands issued by the IDE to the debugger.",
+								"default": false
+							},
+							"skipFiles": {
+								"type": "array",
+								"description": "Omit files matching any of these regexes from stack traces, and automatically step through them when debugging.",
+								"default": []
+							},
+							"finishFiles": {
+								"type": "array",
+								"description": "Automatically step out of files matching these regexes during debugging.",
+								"default": []
+							},
 							"args": {
 								"type": "array",
 								"description": "Command line arguments passed to the program.",
@@ -701,6 +716,21 @@
 								"type": "boolean",
 								"description": "Show output of the debugger in the console.",
 								"default": false
+							},
+							"showDebuggerCommands": {
+								"type": "boolean",
+								"description": "Show commands issued by the IDE to the debugger.",
+								"default": false
+							},
+							"skipFiles": {
+								"type": "array",
+								"description": "Omit files matching any of these regexes from stack traces, and automatically step through them when debugging.",
+								"default": []
+							},
+							"finishFiles": {
+								"type": "array",
+								"description": "Automatically step out of files matching these regexes during debugging.",
+								"default": []
 							}
 						}
 					}

--- a/packages/vscode-ruby-debugger/src/interface.ts
+++ b/packages/vscode-ruby-debugger/src/interface.ts
@@ -12,6 +12,12 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
     stopOnEntry?: boolean;
     /** Show debugger process output. If not specified, there will only be executable output */
     showDebuggerOutput?: boolean;
+    /** Show commands issued by the IDE to the debugger. If not specified, no commands will be shown. */
+    showDebuggerCommands?: boolean;
+    /** Omit files matching any of these regexes from stack traces, and automatically step through them when debugging. */
+    skipFiles: string[];
+    /** Automatically step out of files matching these regexes during debugging. */
+    finishFiles: string[];
     /** Executable working directory. */
     cwd?: string;
 }
@@ -29,6 +35,12 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
     remoteWorkspaceRoot?: string;
     /** Show debugger process output. If not specified, there will only be executable output */
     showDebuggerOutput?: boolean;
+    /** Show commands issued by the IDE to the debugger. If not specified, no commands will be shown. */
+    showDebuggerCommands?: boolean;
+    /** Omit files matching any of these regexes from stack traces, and automatically step through them when debugging. */
+    skipFiles: string[];
+    /** Automatically step out of files matching these regexes during debugging. */
+    finishFiles: string[];
 }
 
 export interface IRubyEvaluationResult {

--- a/packages/vscode-ruby-debugger/src/ruby.ts
+++ b/packages/vscode-ruby-debugger/src/ruby.ts
@@ -296,6 +296,7 @@ export class RubyProcess extends EventEmitter {
     }
 
     public Run(cmd: string): void {
+        this.emit('debuggerCommands', 'command: "' + cmd + '"');
         if (this.state !== SocketClientState.connected) {
             var newCommand = {
                 command: cmd,
@@ -310,6 +311,7 @@ export class RubyProcess extends EventEmitter {
     }
 
     public Enqueue(cmd: string): Promise<any> {
+        this.emit('debuggerCommands', 'command(async): "' + cmd + '"');
         var pro = new Promise<any>((resolve, reject) => {
             var newCommand = {
                 command: cmd,


### PR DESCRIPTION
At Stripe, we use sorbet and other internal utilities that 'pollute' the stack - they create
a large number of frames that are not interesting to our developers when debugging. This commit
adds two features that help avoid those frames.

skipFiles was inspired by the corresponding js debugger feature. It's useful for avoiding
uninteresting frames that are between interesting frames (sorbet falls in to this category).
Skipped files do not appear in stack traces, an the debugger automatically steps through them.

finishFiles is useful for avoiding frames that define the top of a never-interesting call stack.
The debugger automatically steps out of them instead of through them.

showDebuggerCommands is like showDebuggerOutput, but in the other direction. I found it useful
when debugging both features.

- [?] The build passes - the same 3 tests fail with or without this commit
- [?] TSLint is mostly happy
- [ ] Prettier has been run - no, but I did touch things up when I was already changing a line. Running prettier deserves a commit of its own.