### PR TITLE
Clarify `rubyLocate` option in legacy docs

### DIFF
--- a/docs/legacy.md
+++ b/docs/legacy.md
@@ -149,3 +149,5 @@ The defaults will include all files with the `rb` extension, but avoids searchin
 If you change these settings, currently you will need to reload your workspace.
 
 We now provide go to definition within `erb` files, as well as syntax highlighting for `erb`.
+
+There is no built-in 'non-legacy' replacement for `rubyLocate`, but the Solargraph project is a possible alternative.


### PR DESCRIPTION
Based on the discussion in #599, if the comments from @wingrunr21 is still valid then I think this would help clarify the current situation.