### PR TITLE
feat(erb): add HTML onEnterRules

### DIFF
--- a/packages/vscode-ruby/language-configuration-erb.json
+++ b/packages/vscode-ruby/language-configuration-erb.json
@@ -27,5 +27,29 @@
 		["`", "`"],
 		["<", ">"],
 		["%", "%"]
+	],
+	"onEnterRules": [
+		{
+			"beforeText": {
+				"pattern": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)(?:(?:[^'\"/>]|\"[^\"]*\"|'[^']*')*?(?!\\/)>)[^<]*$",
+				"flags": "i"
+			},
+			"afterText": {
+				"pattern": "^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>",
+				"flags": "i"
+			},
+			"action": {
+				"indent": "indentOutdent"
+			}
+		},
+		{
+			"beforeText": {
+				"pattern": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)(?:(?:[^'\"/>]|\"[^\"]*\"|'[^']*')*?(?!\\/)>)[^<]*$",
+				"flags": "i"
+			},
+			"action": {
+				"indent": "indent"
+			}
+		}
 	]
 }


### PR DESCRIPTION
This brings the same on-enter behavior from the HTML language package to ERB. Specifically, when the cursor is between a start and end tag, the editor inserts a new line, puts the cursor at the new indent, and moves the closing tag to the line below at the proper indent.

Currently ERB has this behavior:

![2021-12-23 21 52 43](https://user-images.githubusercontent.com/39493/147310506-a81247e4-7a77-4d08-8e87-20062c96b06d.gif)

After this change it works like this:

![2021-12-23 21 53 59](https://user-images.githubusercontent.com/39493/147310583-53608bf8-c87b-4ae2-b5fc-8adb36e348c1.gif)


This is my first contribution here and I had problems running `yarn watch`. (There was an error with copying tree-sitter.wasm) However run and debug worked fine and I was able to test manually. I'm happy to add tests if someone can provide some direction.

- [ ] The build passes
- [x] TSLint is mostly happy
- [ ] Prettier has been run