### PR TITLE
Fix build failuer if dist directory dosen't exists.

### DIFF
--- a/packages/language-server-ruby/esbuild.js
+++ b/packages/language-server-ruby/esbuild.js
@@ -10,11 +10,11 @@ const treeSitterWasmPlugin = {
       require.resolve('web-tree-sitter/tree-sitter.wasm'),
       require.resolve('web-tree-sitter-ruby/tree-sitter-ruby.wasm')
     ];
-    // build.onEnd(result => {
-    wasmPaths.forEach(wasmPath => {
-      fs.copyFileSync(wasmPath, path.join(outDir, path.basename(wasmPath)))
-    });
-    // })
+    build.onEnd(() => {
+      wasmPaths.forEach(wasmPath => {
+        fs.copyFileSync(wasmPath, path.join(outDir, path.basename(wasmPath)))
+      });
+    })
   }
 }
 


### PR DESCRIPTION
Fix #792.
I don't know why commented out `build.onEnd...` line.
But, i think it is required in the first time build.

- [ ] ~The build passes~
- [ ] ~TSLint is mostly happy~
- [ ] ~Prettier has been run~

No affect by this PR.