### PR TITLE
fix(rake): use bundler with rake when configured

### DIFF
--- a/packages/vscode-ruby-client/src/task/rake.ts
+++ b/packages/vscode-ruby-client/src/task/rake.ts
@@ -113,7 +113,7 @@ async function getRakeTasks(): Promise<vscode.Task[]> {
 						type: 'rake',
 						task: taskName
 					};
-					let task = new vscode.Task(kind, taskName, 'rake', new vscode.ShellExecution(`rake ${taskName}`));
+					let task = new vscode.Task(kind, taskName, 'rake', new vscode.ShellExecution(`${useBundler ? `${pathToBundler}${ext} exec ` : ''}rake ${taskName}`));
 					result.push(task);
 					let lowerCaseLine = line.toLowerCase();
 					if (isBuildTask(lowerCaseLine)) {

--- a/packages/vscode-ruby-client/src/task/rake.ts
+++ b/packages/vscode-ruby-client/src/task/rake.ts
@@ -88,7 +88,11 @@ async function getRakeTasks(): Promise<vscode.Task[]> {
 		}
 	}
 
-	let commandLine = 'rake -AT';
+	const useBundler = vscode.workspace.getConfiguration('ruby').useBundler;
+	const ext: string = process.platform === 'win32' ? '.bat' : '';
+	const pathToBundler: string = vscode.workspace.getConfiguration('ruby').pathToBundler || 'bundle';
+
+	let commandLine = useBundler ? `${pathToBundler}${ext} exec rake -AT` : 'rake -AT';
 	try {
 		let { stdout, stderr } = await exec(commandLine, { cwd: workspaceRoot });
 		if (stderr && stderr.length > 0) {


### PR DESCRIPTION
Respect the useBundler setting from the config when running rake

#278

*Description of change and why it was needed here*

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run