### PR TITLE
`rake` snippet should not assume Rails is present

### DIFF
--- a/packages/vscode-ruby/snippets/ruby.json
+++ b/packages/vscode-ruby/snippets/ruby.json
@@ -180,7 +180,7 @@
 		"body": [
 			"namespace :${1} do",
 			"\tdesc \"${2}\"",
-			"\ttask ${3}: :environment do",
+			"\ttask :${3} do",
 			"\t\t${4}",
 			"\tend",
 			"end"


### PR DESCRIPTION
The `:environment` dependency is specific to Rails.