### PR TITLE
fix undefined tree in document highlight analyzer

### DIFF
--- a/packages/language-server-ruby/src/analyzers/DocumentHighlightAnalyzer.ts
+++ b/packages/language-server-ruby/src/analyzers/DocumentHighlightAnalyzer.ts
@@ -17,7 +17,9 @@ export default class DocumentHighlightAnalyzer {
 
 	public static async analyze(uri: string, position: Position): Promise<DocumentHighlight[]> {
 		const tree: Tree = forest.getTree(uri);
-
+    		if (tree === undefined) {
+      			return []
+    		}
 		return this.computeHighlights(tree, position);
 	}
 


### PR DESCRIPTION
It is possible for tree to be undefined in document highlight analyzer. This causes all sorts of errors in vscode for our users. This PR fixes that behaviour.

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run