### PR TITLE
fix(language-server-ruby): call `node.isName` to get its value

### DIFF
--- a/packages/language-server-ruby/src/analyzers/DocumentHighlightAnalyzer.ts
+++ b/packages/language-server-ruby/src/analyzers/DocumentHighlightAnalyzer.ts
@@ -28,7 +28,7 @@ export default class DocumentHighlightAnalyzer {
 		if (node.type === 'end') {
 			highlights = highlights.concat(this.computeEndHighlight(node));
 		}
-		if (!node.isNamed && this.BEGIN_TYPES.has(node.type)) {
+		if (!node.isNamed() && this.BEGIN_TYPES.has(node.type)) {
 			highlights = highlights.concat(this.computeBeginHighlight(node));
 		}
 		return highlights;


### PR DESCRIPTION
Changing a condition to test the return value of `node.isNamed()`, rather than the presence of an `isNamed` property.

Before making this change, I verified that [web-tree-sitter's type defs](https://github.com/tree-sitter/tree-sitter/blob/0e26fbe5e6d74b178b4f4b3ac318e2851bb0019b/lib/binding_web/tree-sitter-web.d.ts#L84) and [tree-sitter's implementation](https://github.com/tree-sitter/tree-sitter/blob/ccd6bf554d922596ce905730d98a77af368bba5c/lib/binding_web/binding.js#L230-L233)  agree that `isNamed` is a function.

- [ ] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run