### PR TITLE
Use linter.command for formating too

### DIFF
--- a/packages/language-server-ruby/src/formatters/RuboCop.ts
+++ b/packages/language-server-ruby/src/formatters/RuboCop.ts
@@ -7,8 +7,12 @@ export default class RuboCop extends BaseFormatter {
 	protected FORMATTED_OUTPUT_REGEX = new RegExp(`^${this.FORMATTED_OUTPUT_DELIMITER}$`, 'm');
 
 	get cmd(): string {
-		const command = 'rubocop';
-		return this.isWindows() ? command + '.bat' : command;
+		if (this.lintConfig.command) {
+			return this.lintConfig.command;
+		} else {
+			const command = 'rubocop';
+			return this.isWindows() ? command + '.bat' : command;
+		}
 	}
 
 	get args(): string[] {


### PR DESCRIPTION
Use linter.command for formating too so we can at least use our custom commands in an sh file, because currently its impossible to give arguments or config files to rubocop and its extremely annoying

Solves https://github.com/rubyide/vscode-ruby/issues/578

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run