### PR TITLE
Fix Build Process

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,6 @@
 	],
 	"npmClient": "yarn",
 	"useWorkspaces": true,
-	"version": "0.27.0"
+	"version": "0.27.0",
+	"concurrency": 1
 }

--- a/packages/language-server-ruby/esbuild.js
+++ b/packages/language-server-ruby/esbuild.js
@@ -3,6 +3,10 @@ const path = require('path');
 
 const outDir = 'dist';
 
+if (!fs.existsSync(outDir)) {
+  fs.mkdirSync(outDir);
+}
+
 const treeSitterWasmPlugin = {
   name: 'treeSitterWasm',
   setup(build) {


### PR DESCRIPTION
Currently, `yarn run build` won't run through if `packages/language-server-ruby/dist` directory doesn't exist.
Changes made in this PR will add a piece of code to fix this issue.

- [x] The build passes
- [x] TSLint is mostly happy
- [x] Prettier has been run