### PR TITLE
fix default extension not being .rb on create

### DIFF
--- a/packages/vscode-ruby-client/package.json
+++ b/packages/vscode-ruby-client/package.json
@@ -457,6 +457,7 @@
 				],
 				"firstLine": "^#!\\s*/.*(?:ruby|rbx|rake)\\b",
 				"extensions": [
+					".rb",
 					".arb",
 					".builder",
 					".cgi",
@@ -472,7 +473,6 @@
 					".pryrc",
 					".rabl",
 					".rake",
-					".rb",
 					".rbuild",
 					".rbw",
 					".rbx",

--- a/packages/vscode-ruby/package.json
+++ b/packages/vscode-ruby/package.json
@@ -69,6 +69,7 @@
         ],
         "firstLine": "^#!\\s*/.*(?:ruby|rbx|rake)\\b",
         "extensions": [
+          ".rb",
           ".arb",
           ".builder",
           ".cgi",
@@ -84,7 +85,6 @@
           ".pryrc",
           ".rabl",
           ".rake",
-          ".rb",
           ".rbuild",
           ".rbw",
           ".rbx",


### PR DESCRIPTION
Fixes #770

`.arb` extension being on top of the list makes it being used as default extension when creating Ruby files, which is different from commonly used `.rb`. This PR tries to resolve this issue.