### PR TITLE
Clarify lint cops flag

### DIFF
--- a/docs/linting.md
+++ b/docs/linting.md
@@ -44,7 +44,7 @@ or
   "rubocop": {
     "command": "rubocop",  // setting this will override automatic detection
     "useBundler": true,
-    "lint": true, // enable lint cops
+    "lint": true, // run only lint cops
     "only": ["array", "of", "cops", "to", "run"],
     "except": ["array", "of", "cops", "not", "to", "run"],
     "require": ["array", "of", "ruby", "files", "to", "require"],


### PR DESCRIPTION
The `"lint": true` parameter comment was misleading (as if we are "activating/enabling" lint cops but in reality, it "only" runs the lint cops via `-l` flag as documented in Rubocop docs).

