### PR TITLE
Fix minor misspelling in first line of language-server.md

### DIFF
--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -1,6 +1,6 @@
 # Language Server
 
-`language-server-ruby` is an implementation of the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) in TypeScript with the intention of targetting the Ruby programming language.
+`language-server-ruby` is an implementation of the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) in TypeScript with the intention of targeting the Ruby programming language.
 
 The server is built to be extensible, accurate, and performant with such features as:
 


### PR DESCRIPTION
The first line contains a misspelling that does not have any functional impact.

N/A on testing