### PR TITLE
Pass valid filenames to formatter RuboCop 

### DIFF
--- a/packages/language-server-ruby/src/formatters/RuboCop.ts
+++ b/packages/language-server-ruby/src/formatters/RuboCop.ts
@@ -13,7 +13,7 @@ export default class RuboCop extends BaseFormatter {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		const args = ['-s', `'${documentPath.fsPath}'`, '-a'];
+		const args = ['-s', documentPath.fsPath, '-a'];
 		return args;
 	}
 


### PR DESCRIPTION
Closes rubyide#227.

*Description of change and why it was needed here*

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run