### PR TITLE
Update example Standard Ruby command to standardrb

### DIFF
--- a/docs/linting.md
+++ b/docs/linting.md
@@ -73,7 +73,7 @@ or
 ```json
 "ruby.lint": {
   "standard": {
-    "command": "standard",  // setting this will override automatic detection
+    "command": "standardrb",  // setting this will override automatic detection
     "useBundler": true,
     "only": ["array", "of", "cops", "to", "run"],
     "except": ["array", "of", "cops", "not", "to", "run"],


### PR DESCRIPTION
Correct me if I'm wrong here, but I suspect this should be the gem's included executable's name, which is `standardrb` (to disambiguate from Standard.js's `standard)`