### PR TITLE
fix: actually respect pathToRDebugIDE

### DIFF
--- a/packages/vscode-ruby-debugger/src/ruby.ts
+++ b/packages/vscode-ruby-debugger/src/ruby.ts
@@ -65,6 +65,9 @@ export class RubyProcess extends EventEmitter {
             rdebugIdePath: rdebugIdeDefault
         }
 
+        if (args.pathToRDebugIDE) {
+            result.rdebugIdePath = args.pathToRDebugIDE;
+        }
         if (args.pathToRuby) {
             result.pathToRuby = args.pathToRuby;
         }


### PR DESCRIPTION
The property was being ignored despite being documented.

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run