### PR TITLE
Update rubyfmt to pass in --header-opt-out args

### DIFF
--- a/packages/language-server-ruby/src/formatters/RubyFMT.ts
+++ b/packages/language-server-ruby/src/formatters/RubyFMT.ts
@@ -6,7 +6,8 @@ export default class RubyFMT extends BaseFormatter {
 	}
 
 	get args(): string[] {
-		return [];
+		const args = ['--header-opt-out'];
+		return args;
 	}
 
 	get useBundler(): boolean {


### PR DESCRIPTION
This is to allow to skip formatting files with a `# rubyfmt: false` comment at the top of the file.

https://github.com/penelopezone/rubyfmt/issues/354

We can't use a custom binary as then it is not a formatter option that is allowed by the VSCode extension.