### PR TITLE
Revert "Wrap documentPath.fsPath in single quotes to support file paths with spaces"

### DIFF
--- a/packages/language-server-ruby/src/formatters/RuboCop.ts
+++ b/packages/language-server-ruby/src/formatters/RuboCop.ts
@@ -13,7 +13,7 @@ export default class RuboCop extends BaseFormatter {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		const args = ['-s', `'${documentPath.fsPath}'`, '-a'];
+		const args = ['-s', documentPath.fsPath, '-a'];
 		return args;
 	}
 

--- a/packages/language-server-ruby/src/formatters/Rufo.ts
+++ b/packages/language-server-ruby/src/formatters/Rufo.ts
@@ -9,6 +9,6 @@ export default class Rubocop extends BaseFormatter {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		return [`--filename='${documentPath.fsPath}'`, '-x'];
+		return [`--filename=${documentPath.fsPath}`, '-x'];
 	}
 }

--- a/packages/language-server-ruby/src/formatters/Standard.ts
+++ b/packages/language-server-ruby/src/formatters/Standard.ts
@@ -9,7 +9,7 @@ export default class Standard extends RuboCop {
 
 	get args(): string[] {
 		const documentPath = URI.parse(this.document.uri);
-		const args = ['-s', `'${documentPath.fsPath}'`, '--fix'];
+		const args = ['-s', documentPath.fsPath, '--fix'];
 		return args;
 	}
 }


### PR DESCRIPTION
This reverts commit d432fee5e6dcd3b3a2ec1e43a7fc9a5a8cea915d.

Closes #227, supercedes #825.

*It broke everything and pieces have already been reverted in several other PRs*

- [] The build passes
- [] TSLint is mostly happy
- [] Prettier has been run